### PR TITLE
Add simple chart example

### DIFF
--- a/QuestPDF.Examples/ChartExamples.cs
+++ b/QuestPDF.Examples/ChartExamples.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using QuestPDF.Examples.Engine;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+using Microcharts;
+using SkiaSharp;
+
+namespace QuestPDF.Examples
+{    
+    public class ChartExample
+    {
+        [Test]
+        public void MicrochartChart()
+        {
+            var entries = new[]
+            {
+                new ChartEntry(212)
+                {
+                    Label = "UWP",
+                    ValueLabel = "112",
+                    Color = SKColor.Parse("#2c3e50")
+                },
+                new ChartEntry(248)
+                {
+                    Label = "Android",
+                    ValueLabel = "648",
+                    Color = SKColor.Parse("#77d065")
+                },
+                new ChartEntry(128)
+                {
+                    Label = "iOS",
+                    ValueLabel = "428",
+                    Color = SKColor.Parse("#b455b6")
+                },
+                new ChartEntry(514)
+                {
+                    Label = "Forms",
+                    ValueLabel = "214",
+                    Color = SKColor.Parse("#3498db")
+                }
+            };
+
+            RenderingTest
+                .Create()
+                .PageSize(300, 300)
+                .ShowResults()
+                .Render(container =>
+                {
+                    container.Extend().Canvas((canvas, size) => 
+                    {
+                        var bar = new BarChart
+                        {
+                            Entries = entries,
+                            IsAnimated = false,
+                        };
+                        bar.Draw(canvas, (int)size.Width, (int)size.Height);
+                    });
+                });
+        }
+    }
+}

--- a/QuestPDF.Examples/QuestPDF.Examples.csproj
+++ b/QuestPDF.Examples/QuestPDF.Examples.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="microcharts" Version="0.9.5.9" />
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />


### PR DESCRIPTION
I've added the base example from the current release of Microcharts (0.9.5.9), pretty straightforward IMO, with the only real gotcha is to ensure that IsAnimated is set to false, otherwise the chart will be rendered at the initial animation position (which will give you no visible chart).