### PR TITLE
fix rendering direct to aspnet core response stream

### DIFF
--- a/QuestPDF/Drawing/PdfCanvas.cs
+++ b/QuestPDF/Drawing/PdfCanvas.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using QuestPDF.Infrastructure;
+using QuestPDF.Helpers;
 using SkiaSharp;
 
 namespace QuestPDF.Drawing
@@ -7,7 +7,7 @@ namespace QuestPDF.Drawing
     internal class PdfCanvas : SkiaDocumentCanvasBase
     {
         public PdfCanvas(Stream stream, DocumentMetadata documentMetadata) 
-            : base(SKDocument.CreatePdf(stream, MapMetadata(documentMetadata)))
+            : base(SKDocument.CreatePdf(new WriteStreamWrapper(stream), MapMetadata(documentMetadata)))
         {
             
         }

--- a/QuestPDF/Drawing/XpsCanvas.cs
+++ b/QuestPDF/Drawing/XpsCanvas.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using QuestPDF.Infrastructure;
+using QuestPDF.Helpers;
 using SkiaSharp;
 
 namespace QuestPDF.Drawing
@@ -7,7 +7,7 @@ namespace QuestPDF.Drawing
     internal class XpsCanvas : SkiaDocumentCanvasBase
     {
         public XpsCanvas(Stream stream, DocumentMetadata documentMetadata) 
-            : base(SKDocument.CreateXps(stream, documentMetadata.RasterDpi))
+            : base(SKDocument.CreateXps(new WriteStreamWrapper(stream), documentMetadata.RasterDpi))
         {
             
         }

--- a/QuestPDF/Helpers/WriteStreamWrapper.cs
+++ b/QuestPDF/Helpers/WriteStreamWrapper.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+
+namespace QuestPDF.Helpers
+{
+    internal class WriteStreamWrapper : Stream
+    {
+        private readonly Stream _innerStream;
+
+        private long _length;
+
+        public WriteStreamWrapper(Stream stream)
+        {            
+            if (!stream.CanWrite)
+            {
+                throw new NotSupportedException("Stream cannot be written");
+            }
+
+            _innerStream = stream;
+        }
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => _length;
+
+        public override long Position { 
+            get => _length; 
+            set => throw new NotImplementedException(); 
+        }
+
+        public override void Flush() 
+            => _innerStream.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) 
+            => throw new NotImplementedException();
+
+        public override long Seek(long offset, SeekOrigin origin) 
+            => throw new NotImplementedException();
+
+        public override void SetLength(long value) 
+            => throw new NotImplementedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _innerStream.Write(buffer, offset, count);
+            _length += count;
+        }
+    }
+}


### PR DESCRIPTION
adding a WrapperStream to support streams that not implement the Position property needed by SkiaSharp.
e.g. useful for the aspnet core response stream

fix #52