### PR TITLE
Add ObjectElement and ICanvas support for it

### DIFF
--- a/QuestPDF/Drawing/FreeCanvas.cs
+++ b/QuestPDF/Drawing/FreeCanvas.cs
@@ -76,6 +76,13 @@ namespace QuestPDF.Drawing
             
         }
 
+        public void DrawObject(object Object, Position position, Size size)
+        {
+            
+        }
+
+
+
         #endregion
     }
 }

--- a/QuestPDF/Drawing/SkiaCanvasBase.cs
+++ b/QuestPDF/Drawing/SkiaCanvasBase.cs
@@ -61,5 +61,10 @@ namespace QuestPDF.Drawing
         {
             Canvas.Scale(scaleX, scaleY);
         }
+
+        public void DrawObject(object Object, Position position, Size size)
+        {
+            throw new System.NotImplementedException($"{nameof(SkiaCanvasBase)} does not currently implement drawing for ObjectElement");
+        }
     }
 }

--- a/QuestPDF/Elements/ObjectElement.cs
+++ b/QuestPDF/Elements/ObjectElement.cs
@@ -7,6 +7,7 @@ namespace QuestPDF.Elements
     internal class ObjectElement : Element, ICacheable
     {
         public object? Object { get; set; }
+        public AspectRatioOption SpaceFitBehavior { get; set; }
 
         internal override SpacePlan Measure(Size availableSpace)
         {

--- a/QuestPDF/Elements/ObjectElement.cs
+++ b/QuestPDF/Elements/ObjectElement.cs
@@ -1,0 +1,24 @@
+using QuestPDF.Drawing;
+using QuestPDF.Infrastructure;
+using SkiaSharp;
+
+namespace QuestPDF.Elements
+{
+    internal class ObjectElement : Element, ICacheable
+    {
+        public object? Object { get; set; }
+
+        internal override SpacePlan Measure(Size availableSpace)
+        {
+            return SpacePlan.FullRender(availableSpace);
+        }
+
+        internal override void Draw(Size availableSpace)
+        {
+            if (Object == null)
+                return;
+
+            Canvas.DrawObject(Object, Position.Zero, availableSpace);
+        }
+    }
+}

--- a/QuestPDF/Fluent/ObjectElementExtensions.cs
+++ b/QuestPDF/Fluent/ObjectElementExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using QuestPDF.Drawing.Exceptions;
+using QuestPDF.Elements;
+using QuestPDF.Infrastructure;
+using SkiaSharp;
+
+namespace QuestPDF.Fluent
+{
+    public static class ObjectElementExtensions
+    {
+        /// <summary>
+        /// Add an inspecific object. To use this feature, your ICanvas must implement DrawObject().
+        /// </summary>
+        public static void Object(this IContainer parent, object Object, AspectRatioOption fitSpaceOption = AspectRatioOption.FitWidth)
+        {
+            parent.Element(
+                new ObjectElement()
+                {
+                    Object = Object,
+                    SpaceFitBehavior = fitSpaceOption
+                });
+        }
+    }
+}

--- a/QuestPDF/Infrastructure/ICanvas.cs
+++ b/QuestPDF/Infrastructure/ICanvas.cs
@@ -1,14 +1,16 @@
 using SkiaSharp;
+using System;
 
 namespace QuestPDF.Infrastructure
 {
-    internal interface ICanvas
+    public interface ICanvas
     {
         void Translate(Position vector);
         
         void DrawRectangle(Position vector, Size size, string color);
         void DrawText(string text, Position position, TextStyle style);
         void DrawImage(SKImage image, Position position, Size size);
+        void DrawObject(object Object, Position position, Size size);
 
         void DrawExternalLink(string url, Size size);
         void DrawLocationLink(string locationName, Size size);

--- a/QuestPDF/Infrastructure/Position.cs
+++ b/QuestPDF/Infrastructure/Position.cs
@@ -1,6 +1,6 @@
 ﻿namespace QuestPDF.Infrastructure
 {
-    internal readonly struct Position
+    public readonly struct Position
     {
         public readonly float X;
         public readonly float Y;


### PR DESCRIPTION
There are two commits that demonstrate the requested feature change.

I haven't tested this yet, but I thought it was easier to go ahead and present the idea in a new branch rather than continue back and forth in [Discussion #78](https://github.com/QuestPDF/QuestPDF/discussions/78).

Basically, there's a new element called ObjectElement. It only has two properties:  an Object and a FitSpaceBehavior.

When ObjectElement.Draw() is called, it calls ICanvas.DrawObject() passing the Object so the canvas has free control to analyze the object and decide how to draw it.

This allows custom implementations of ICanvas without limitation on what kinds of things can be drawn.   And it avoids custom delegates everywhere you declare an ObjectElement.  In the fluent builder construction, this allows the user to focus on "what" he is rendering instead of "how" to render it.

ISSUES:
I don't understand how your positioning system works yet.  Right now the call to Canvas.DrawObject() passes Position.Zero.  But I don't think that's correct.  How do you pass the correct position to the ICanvas so it knows where to draw the element?