### PR TITLE
FontManager: Add support for multiple variants of font families registered at runtime

### DIFF
--- a/QuestPDF.UnitTests/FontStyleSetTests.cs
+++ b/QuestPDF.UnitTests/FontStyleSetTests.cs
@@ -1,0 +1,123 @@
+﻿using NUnit.Framework;
+using QuestPDF.Drawing;
+using SkiaSharp;
+
+namespace QuestPDF.UnitTests
+{
+    [TestFixture]
+    public class FontStyleSetTests
+    {
+        private void ExpectComparisonOrder(SKFontStyle target, params SKFontStyle[] styles)
+        {
+            for (int i = 0; i < styles.Length - 1; i++)
+            {
+                Assert.True(FontStyleSet.IsBetterMatch(target, styles[i], styles[i + 1]));
+                Assert.False(FontStyleSet.IsBetterMatch(target, styles[i + 1], styles[i]));
+            }
+        }
+
+        [Test]
+        public void FontStyleSet_IsBetterMatch_CondensedWidth()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 4, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 3, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 6, SKFontStyleSlant.Upright)
+            );
+        }
+
+        [Test]
+        public void FontStyleSet_IsBetterMatch_ExpandedWidth()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(500, 6, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 6, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 7, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 8, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright)
+            );
+        }
+
+        [Test]
+        public void FontStyleSet_IsBetterMatch_ItalicSlant()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(500, 5, SKFontStyleSlant.Italic),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Italic),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Oblique),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright)
+            );
+        }
+
+        [Test]
+        public void FontStyleSet_IsBetterMatch_ObliqueSlant()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(500, 5, SKFontStyleSlant.Oblique),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Oblique),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Italic),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright)
+            );
+        }
+
+        [Test]
+        public void FontStyleSet_IsBetterMatch_UprightSlant()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Oblique),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Italic)
+            );
+        }
+
+        [Test]
+        public void FontStyleSet_IsBetterMatch_ThinWeight()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(300, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(300, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(200, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(100, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(400, 5, SKFontStyleSlant.Upright)
+            );
+        }
+
+        [Test]
+        public void FontStyleSet_IsBetterMatch_RegularWeight()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(400, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(300, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(100, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(600, 5, SKFontStyleSlant.Upright)
+            );
+        }
+
+        [Test]
+        public void FontStyleSet_IsBetterMatch_BoldWeight()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(600, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(600, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(700, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(800, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright)
+            );
+        }
+
+        [Test]
+        public void FontStyleSet_RespectsPriority()
+        {
+            ExpectComparisonOrder(
+                new SKFontStyle(500, 5, SKFontStyleSlant.Upright),
+                new SKFontStyle(600, 5, SKFontStyleSlant.Italic),
+                new SKFontStyle(600, 6, SKFontStyleSlant.Upright),
+                new SKFontStyle(500, 6, SKFontStyleSlant.Italic)
+            );
+        }
+    }
+}

--- a/QuestPDF/Drawing/FontStyleSet.cs
+++ b/QuestPDF/Drawing/FontStyleSet.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using SkiaSharp;
+
+namespace QuestPDF.Drawing
+{
+    internal class FontStyleSet
+    {
+        private ConcurrentDictionary<SKFontStyle, SKTypeface> Styles = new ConcurrentDictionary<SKFontStyle, SKTypeface>();
+
+        public void Add(SKTypeface typeface)
+        {
+            SKFontStyle style = typeface.FontStyle;
+            Styles.AddOrUpdate(style, (_) => typeface, (_, _) => typeface);
+        }
+
+        public SKTypeface Match(SKFontStyle target)
+        {
+            SKFontStyle bestStyle = null;
+            SKTypeface bestTypeface = null;
+
+            foreach (var entry in Styles)
+            {
+                if (IsBetterMatch(target, entry.Key, bestStyle))
+                {
+                    bestStyle = entry.Key;
+                    bestTypeface = entry.Value;
+                }
+            }
+
+            return bestTypeface;
+        }
+
+        private static Dictionary<SKFontStyleSlant, List<SKFontStyleSlant>> SlantFallbacks = new()
+        {
+            { SKFontStyleSlant.Italic, new() { SKFontStyleSlant.Italic, SKFontStyleSlant.Oblique, SKFontStyleSlant.Upright } },
+            { SKFontStyleSlant.Oblique, new() { SKFontStyleSlant.Oblique, SKFontStyleSlant.Italic, SKFontStyleSlant.Upright } },
+            { SKFontStyleSlant.Upright, new() { SKFontStyleSlant.Upright, SKFontStyleSlant.Oblique, SKFontStyleSlant.Italic } },
+        };
+
+        // Checks whether style a is a better match for the target then style b. Uses the CSS font style matching algorithm
+        internal static bool IsBetterMatch(SKFontStyle target, SKFontStyle a, SKFontStyle b)
+        {
+            // A font is better than no font
+            if (b == null) return true;
+            if (a == null) return false;
+
+            // First check font width
+            // For normal and condensed widths prefer smaller widths
+            // For expanded widths prefer larger widths
+            if (target.Width <= (int)SKFontStyleWidth.Normal)
+            {
+                if (a.Width <= target.Width && b.Width > target.Width) return true;
+                if (a.Width > target.Width && b.Width <= target.Width) return false;
+            }
+            else
+            {
+                if (a.Width >= target.Width && b.Width < target.Width) return true;
+                if (a.Width < target.Width && b.Width >= target.Width) return false;
+            }
+
+            // Prefer closest match
+            int widthDifferenceA = Math.Abs(a.Width - target.Width);
+            int widthDifferenceB = Math.Abs(b.Width - target.Width);
+
+            if (widthDifferenceA < widthDifferenceB) return true;
+            if (widthDifferenceB < widthDifferenceA) return false;
+
+            // Prefer closest slant based on provided fallback list
+            List<SKFontStyleSlant> slantFallback = SlantFallbacks[target.Slant];
+            int slantIndexA = slantFallback.IndexOf(a.Slant);
+            int slantIndexB = slantFallback.IndexOf(b.Slant);
+
+            if (slantIndexA < slantIndexB) return true;
+            if (slantIndexB < slantIndexA) return false;
+
+            // Check weight last
+            // For thin (<400) weights, prefer thinner weights
+            // For regular (400-500) weights, prefer other regular weights, then use rule for thin or bold
+            // For bold (>500) weights, prefer thicker weights
+            // Behavior for values other than multiples of 100 is not given in the specification
+
+            if (target.Weight >= 400 && target.Weight <= 500)
+            {
+                if ((a.Weight >= 400 && a.Weight <= 500) && !(b.Weight >= 400 && b.Weight <= 500)) return true;
+                if (!(a.Weight >= 400 && a.Weight <= 500) && (b.Weight >= 400 && b.Weight <= 500)) return false;
+            }
+
+            if (target.Weight < 450)
+            {
+                if (a.Weight <= target.Weight && b.Weight > target.Weight) return true;
+                if (a.Weight > target.Weight && b.Weight <= target.Weight) return false;
+            }
+            else
+            {
+                if (a.Weight >= target.Weight && b.Weight < target.Weight) return true;
+                if (a.Weight < target.Weight && b.Weight >= target.Weight) return false;
+            }
+
+            // Prefer closest weight
+            int weightDifferenceA = Math.Abs(a.Weight - target.Weight);
+            int weightDifferenceB = Math.Abs(b.Weight - target.Weight);
+
+            return weightDifferenceA < weightDifferenceB;
+        }
+    }
+}


### PR DESCRIPTION
This commit allows registering multiple variants (thinkness, slant) of the same font. To do so, simply call the `RegisterFontType` method multiple times, once with each style.
Also added an overload that loads the family name from the file itself.
This means you can just put all the fonts you need in a folder and call the method with each file to load them all.

Skia's `SkFontMgr` sadly assumes all fonts will be loaded at once and while it might have support for creating new managers at runtime, I don't think SkiaSharp supports it. As such I've reimplemented the CSS font matching algorithm in C#. It also supports multiple font widths, in case QuestPDF decides to support them in the future.