### PR TITLE
ForceWrap API

### DIFF
--- a/QuestPDF.Examples/TextExamples.cs
+++ b/QuestPDF.Examples/TextExamples.cs
@@ -64,6 +64,30 @@ namespace QuestPDF.Examples
                         });
                 });
         }
+
+        [Test]
+        public void ParagraphSpacingForceWrap()
+        {
+            var spacelessLoremIpsum = Placeholders.LoremIpsum().Replace(" ", string.Empty);
+            
+            RenderingTest
+                .Create()
+                .PageSize(500, 300)
+                .ProduceImages()
+                .ShowResults()
+                .Render(container =>
+                {
+                    container
+                        .Padding(5)
+                        .MinimalBox()
+                        .Border(1)
+                        .Padding(10)
+                        .Text(td =>
+                        {
+                            td.Span(spacelessLoremIpsum).ForceWrap();
+                        });
+                });
+        }
         
         [Test]
         public void CustomElement()

--- a/QuestPDF/Elements/Text/Calculation/TextMeasurementResult.cs
+++ b/QuestPDF/Elements/Text/Calculation/TextMeasurementResult.cs
@@ -16,7 +16,9 @@ namespace QuestPDF.Elements.Text.Calculation
         public int EndIndex { get; set; }
         public int NextIndex { get; set; }
         public int TotalIndex { get; set; }
-
-        public bool IsLast => NextIndex == EndIndex;
+        public bool ForceWrap { get; set; }
+        public bool IsLast => ForceWrap
+            ?  NextIndex == TotalIndex
+            : NextIndex == EndIndex;
     }
 }

--- a/QuestPDF/Elements/Text/Items/TextBlockSpan.cs
+++ b/QuestPDF/Elements/Text/Items/TextBlockSpan.cs
@@ -89,7 +89,7 @@ namespace QuestPDF.Elements.Text.Items
                 Descent = fontMetrics.Descent,
      
                 LineHeight = Style.LineHeight ?? 1,
-                
+                ForceWrap = Style.ForceWrap ?? false,
                 StartIndex = startIndex,
                 EndIndex = endIndex,
                 NextIndex = nextIndex,

--- a/QuestPDF/Fluent/TextSpanDescriptorExtensions.cs
+++ b/QuestPDF/Fluent/TextSpanDescriptorExtensions.cs
@@ -62,6 +62,11 @@ namespace QuestPDF.Fluent
             descriptor.TextStyle.HasUnderline = value;
             return descriptor;
         }
+        public static T ForceWrap<T>(this T descriptor, bool value = true) where T : TextSpanDescriptor
+        {
+            descriptor.TextStyle.ForceWrap = value;
+            return descriptor;
+        }
 
         #region Weight
         

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -16,6 +16,7 @@ namespace QuestPDF.Infrastructure
         internal bool? IsItalic { get; set; }
         internal bool? HasStrikethrough { get; set; }
         internal bool? HasUnderline { get; set; }
+        internal bool? ForceWrap { get; set; }
 
         internal object PaintKey { get; private set; }
         internal object FontMetricsKey { get; private set; }
@@ -34,7 +35,7 @@ namespace QuestPDF.Infrastructure
         };
 
         public static TextStyle Default => new TextStyle();
-        
+
         internal void ApplyGlobalStyle(TextStyle globalStyle)
         {
             if (HasGlobalStyleApplied)


### PR DESCRIPTION
ForceWrap API allows wrapping of strings that do not contain whitespaces so the strings can be rendered in its totality:

![ParagraphSpacingForceWrap](https://user-images.githubusercontent.com/5540896/159350793-f29775e3-6287-46b9-8490-edb502985f9e.png)

