### PR TITLE
Previewer - Fix multiple small issues

### DIFF
--- a/QuestPDF.Previewer.Examples/Program.cs
+++ b/QuestPDF.Previewer.Examples/Program.cs
@@ -7,9 +7,9 @@ using QuestPDF.ReportSample;
 using QuestPDF.ReportSample.Layouts;
 using Colors = QuestPDF.Helpers.Colors;
 
-// var model = DataSource.GetReport();
-// var report = new StandardReport(model);
-// report.ShowInPreviewer();
+var model = DataSource.GetReport();
+var report = new StandardReport(model);
+report.ShowInPreviewer();
 
 Document
     .Create(container =>

--- a/QuestPDF.Previewer/DocumentPreviewerExtensions.cs
+++ b/QuestPDF.Previewer/DocumentPreviewerExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
 using QuestPDF.Infrastructure;
 
 namespace QuestPDF.Previewer
@@ -16,6 +17,19 @@ namespace QuestPDF.Previewer
         public static void ShowInPreviewer(this IDocument document)
         {
             ArgumentNullException.ThrowIfNull(document);
+
+            //Currently there is no way to unitialize a previously run avalonia app.
+            //So we need to check if the previewer was already run and show the window again.
+            if(Application.Current?.ApplicationLifetime is ClassicDesktopStyleApplicationLifetime desktop)
+            {
+                desktop.MainWindow = new PreviewerWindow()
+                {
+                    Document = document,
+                };
+                desktop.MainWindow.Show();
+                desktop.Start(Array.Empty<string>());
+                return;
+            }
 
             AppBuilder
                 .Configure(() => new PreviewerApp()

--- a/QuestPDF.Previewer/InteractiveCanvas.cs
+++ b/QuestPDF.Previewer/InteractiveCanvas.cs
@@ -26,7 +26,7 @@ class InteractiveCanvas : ICustomDrawOperation
     private const float SafeZone = 50f;
 
     public float TotalHeight => Pages.Sum(x => x.Size.Height) + (Pages.Count - 1) * PageSpacing;
-    public float MaxWidth => Pages.Max(x => x.Size.Width);
+    public float MaxWidth => Pages.Any() ? Pages.Max(x => x.Size.Width) : 0;
     public float MaxTranslateY => -(Height / 2 - SafeZone) / Scale;
     public float MinTranslateY => (Height / 2 - SafeZone) / Scale - TotalHeight;
 

--- a/QuestPDF.Previewer/PreviewerWindow.axaml.cs
+++ b/QuestPDF.Previewer/PreviewerWindow.axaml.cs
@@ -65,14 +65,16 @@ namespace QuestPDF.Previewer
             //     .Click += (_, _) => _ = PreviewerUtils.SavePdfWithDialog(Document, this);
 
             DocumentProperty.Changed.Subscribe(v => Task.Run(() => DocumentRenderer.UpdateDocument(v.NewValue.Value)));
-            HotReloadManager.UpdateApplicationRequested += (_, _) => InvalidatePreview();
+            HotReloadManager.UpdateApplicationRequested += InvalidatePreview;
         }
 
-        private void InitializeComponent()
+        protected override void OnClosed(EventArgs e)
         {
-            AvaloniaXamlLoader.Load(this);
+            HotReloadManager.UpdateApplicationRequested -= InvalidatePreview;
+            base.OnClosed(e);
         }
 
+        private void InvalidatePreview(object? sender, EventArgs e) => InvalidatePreview();
         private void InvalidatePreview()
         {
             Dispatcher.UIThread.Post(() =>
@@ -80,6 +82,11 @@ namespace QuestPDF.Previewer
                 var document = Document;
                 _ = Task.Run(() => DocumentRenderer.UpdateDocument(document));
             });
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
         }
     }
 }

--- a/QuestPDF.Previewer/PreviewerWindow.axaml.cs
+++ b/QuestPDF.Previewer/PreviewerWindow.axaml.cs
@@ -23,44 +23,45 @@ namespace QuestPDF.Previewer
             get => GetValue(DocumentProperty);
             set => SetValue(DocumentProperty, value);
         }
-        
-        
-        
-        public static readonly StyledProperty<float> CurrentScrollProperty = AvaloniaProperty.Register<PreviewerControl, float>(nameof(CurrentScroll));
-        
+
+        public static readonly StyledProperty<float> CurrentScrollProperty =
+            AvaloniaProperty.Register<PreviewerWindow, float>(nameof(CurrentScroll));
+
         public float CurrentScroll
         {
             get => GetValue(CurrentScrollProperty);
             set => SetValue(CurrentScrollProperty, value);
         }
-        
-        public static readonly StyledProperty<float> ScrollViewportSizeProperty = AvaloniaProperty.Register<PreviewerControl, float>(nameof(ScrollViewportSize));
-        
+
+        public static readonly StyledProperty<float> ScrollViewportSizeProperty =
+            AvaloniaProperty.Register<PreviewerWindow, float>(nameof(ScrollViewportSize));
+
         public float ScrollViewportSize
         {
             get => GetValue(ScrollViewportSizeProperty);
             set => SetValue(ScrollViewportSizeProperty, value);
         }
-        
-        public static readonly StyledProperty<bool> VerticalScrollbarVisibleProperty = AvaloniaProperty.Register<PreviewerControl, bool>(nameof(VerticalScrollbarVisible));
-        
+
+        public static readonly StyledProperty<bool> VerticalScrollbarVisibleProperty =
+            AvaloniaProperty.Register<PreviewerWindow, bool>(nameof(VerticalScrollbarVisible));
+
         public bool VerticalScrollbarVisible
         {
             get => GetValue(VerticalScrollbarVisibleProperty);
             set => SetValue(VerticalScrollbarVisibleProperty, value);
         }
-        
-        
+
         public PreviewerWindow()
         {
             InitializeComponent();
 
-            ScrollViewportSizeProperty.Changed.Subscribe(_ =>
-            {
-                VerticalScrollbarVisible = ScrollViewportSize < 1;
-                Debug.WriteLine($"Scrollbar visible: {VerticalScrollbarVisible}");
-            });
-            
+            ScrollViewportSizeProperty.Changed
+                .Subscribe(e => Dispatcher.UIThread.Post(() =>
+                {
+                    VerticalScrollbarVisible = e.NewValue.Value < 1;
+                    Debug.WriteLine($"Scrollbar visible: {VerticalScrollbarVisible}");
+                }));
+
             // this.FindControl<Button>("GeneratePdf")
             //     .Click += (_, _) => _ = PreviewerUtils.SavePdfWithDialog(Document, this);
 


### PR DESCRIPTION
This PR fixes 3 Issues regarding the previewer.

- Calling `ShowPreviewer` multiple times lead to an `InvalidOperationException`  when calling `AppBuilder.StartWithClassicDesktopLifetime` [Discussion](https://github.com/QuestPDF/QuestPDF/discussions/145#discussioncomment-2408643).

- Exception when Pages list is empty [Discussion](https://github.com/QuestPDF/QuestPDF/discussions/145#discussioncomment-2408643).

- Scrollbar Visibiltiy [Discussion](https://github.com/QuestPDF/QuestPDF/discussions/145#discussioncomment-2421340).