### PR TITLE
Implement subscript/superscript text

### DIFF
--- a/QuestPDF.Examples/TextExamples.cs
+++ b/QuestPDF.Examples/TextExamples.cs
@@ -65,11 +65,17 @@ namespace QuestPDF.Examples
 
                             text.EmptyLine();
 
-                            var style = TextStyle.Default.Underline().Strikethrough();
+                            text.ParagraphSpacing(2);
+
+                            var style = TextStyle.Default.Underline();
 
                             text.Span("Subscript", style.Subscript().BackgroundColor(Colors.Green.Medium));
                             text.Span("Normal", style.NormalVariant().BackgroundColor(Colors.Blue.Medium));
-                            text.Span("Superscript", style.Superscript().BackgroundColor(Colors.Red.Medium));
+                            text.Line("Superscript", style.Superscript().BackgroundColor(Colors.Red.Medium));
+
+                            text.Line("Superscript", style.Superscript().BackgroundColor(Colors.Green.Medium));
+                            text.Line("Normal", style.NormalVariant().BackgroundColor(Colors.Blue.Medium));
+                            text.Line("Subscript", style.Subscript().BackgroundColor(Colors.Red.Medium));
                         });
                });
         }

--- a/QuestPDF.Examples/TextExamples.cs
+++ b/QuestPDF.Examples/TextExamples.cs
@@ -35,6 +35,42 @@ namespace QuestPDF.Examples
                         });
                 });
         }
+
+        [Test]
+        public void FontVariants()
+        {
+            RenderingTest
+               .Create()
+               .PageSize(500, 300)
+
+               .ProduceImages()
+               .ShowResults()
+               .Render(container =>
+               {
+                   container
+                        .Padding(5)
+                        .MinimalBox()
+                        .Border(1)
+                        .Padding(10)
+                        .Text(text =>
+                        {
+                            text.Span("E=mc");
+                            text.Span("2", TextStyle.Default.Superscript());
+
+                            text.EmptyLine();
+
+                            text.Span("H");
+                            text.Span("2", TextStyle.Default.Subscript());
+                            text.Span("O");
+
+                            text.EmptyLine();
+
+                            text.Span("Subscript", TextStyle.Default.Subscript());
+                            text.Span("Normal", TextStyle.Default.NormalVariant());
+                            text.Span("Superscript", TextStyle.Default.Superscript());
+                        });
+               });
+        }
         
         [Test]
         public void ParagraphSpacing()

--- a/QuestPDF.Examples/TextExamples.cs
+++ b/QuestPDF.Examples/TextExamples.cs
@@ -65,9 +65,11 @@ namespace QuestPDF.Examples
 
                             text.EmptyLine();
 
-                            text.Span("Subscript", TextStyle.Default.Subscript());
-                            text.Span("Normal", TextStyle.Default.NormalVariant());
-                            text.Span("Superscript", TextStyle.Default.Superscript());
+                            var style = TextStyle.Default.Underline().Strikethrough();
+
+                            text.Span("Subscript", style.Subscript().BackgroundColor(Colors.Green.Medium));
+                            text.Span("Normal", style.NormalVariant().BackgroundColor(Colors.Blue.Medium));
+                            text.Span("Superscript", style.Superscript().BackgroundColor(Colors.Red.Medium));
                         });
                });
         }

--- a/QuestPDF/Drawing/FontManager.cs
+++ b/QuestPDF/Drawing/FontManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
+using QuestPDF.Fluent;
 using QuestPDF.Infrastructure;
 using SkiaSharp;
 using SkiaSharp.HarfBuzz;
@@ -118,6 +119,15 @@ namespace QuestPDF.Drawing
         internal static SKFontMetrics ToFontMetrics(this TextStyle style)
         {
             return FontMetrics.GetOrAdd(style.FontMetricsKey, key => style.ToPaint().FontMetrics);
+        }
+
+        /// <summary>
+        /// Returns the normalized font metrics by ignoring the <see cref="FontVariant"/> property.
+        /// </summary>
+        internal static SKFontMetrics ToNormalizedFontMetrics(this TextStyle style)
+        {
+            var fontMetricsKey = (style.FontType, style.Size, style.FontWeight, FontVariant.Normal, style.IsItalic);
+            return FontMetrics.GetOrAdd(fontMetricsKey, key => style.NormalVariant().ToPaint().FontMetrics);
         }
         
         internal static SKShaper ToShaper(this TextStyle style)

--- a/QuestPDF/Drawing/FontManager.cs
+++ b/QuestPDF/Drawing/FontManager.cs
@@ -70,13 +70,18 @@ namespace QuestPDF.Drawing
                 {
                     Color = SKColor.Parse(style.Color),
                     Typeface = GetTypeface(style),
-                    TextSize = style.Size ?? 12
+                    TextSize = (style.Size ?? 12) * GetTextScale(style)
                 };
             }
 
             static SKTypeface GetTypeface(TextStyle style)
             {
                 var weight = (SKFontStyleWeight)(style.FontWeight ?? FontWeight.Normal);
+
+                //Extra weight for superscript and subscript
+                if (style.FontVariant == FontVariant.Superscript || style.FontVariant == FontVariant.Subscript)
+                  weight = (SKFontStyleWeight)((int)weight + 100);
+
                 var slant = (style.IsItalic ?? false) ? SKFontStyleSlant.Italic : SKFontStyleSlant.Upright;
 
                 var fontStyle = new SKFontStyle(weight, SKFontStyleWidth.Normal, slant);
@@ -95,6 +100,14 @@ namespace QuestPDF.Drawing
                     $"1) install the font on your operating system or execution environment. " +
                     $"2) load a font file specifically for QuestPDF usage via the QuestPDF.Drawing.FontManager.RegisterFontType(Stream fileContentStream) static method.");
             }
+        }
+
+        private static float GetTextScale(TextStyle style)
+        {
+            if (style.FontVariant == FontVariant.Superscript || style.FontVariant == FontVariant.Subscript)
+                return 0.65f;
+
+            return 1;
         }
 
         internal static SKFont ToFont(this TextStyle style)

--- a/QuestPDF/Drawing/FontManager.cs
+++ b/QuestPDF/Drawing/FontManager.cs
@@ -126,8 +126,7 @@ namespace QuestPDF.Drawing
         /// </summary>
         internal static SKFontMetrics ToNormalizedFontMetrics(this TextStyle style)
         {
-            var fontMetricsKey = (style.FontType, style.Size, style.FontWeight, FontVariant.Normal, style.IsItalic);
-            return FontMetrics.GetOrAdd(fontMetricsKey, key => style.NormalVariant().ToPaint().FontMetrics);
+            return FontMetrics.GetOrAdd(style.NormalizedFontMetricsKey, key => style.NormalVariant().ToPaint().FontMetrics);
         }
         
         internal static SKShaper ToShaper(this TextStyle style)

--- a/QuestPDF/Elements/Text/Items/TextBlockSpan.cs
+++ b/QuestPDF/Elements/Text/Items/TextBlockSpan.cs
@@ -78,10 +78,12 @@ namespace QuestPDF.Elements.Text.Items
 
             if (!string.IsNullOrWhiteSpace(Text))
             {
+                var offset = GetGlyphOffsetForStyle(Style);
+
                 if (RequiresShaping)
-                    Canvas.DrawShapedText(Text, Position.Zero, Style);
+                    Canvas.DrawShapedText(Text, offset, Style);
                 else
-                    Canvas.DrawText(Text, Position.Zero, Style);
+                    Canvas.DrawText(Text, offset, Style);
             }
 
             // draw underline
@@ -96,6 +98,16 @@ namespace QuestPDF.Elements.Text.Items
             {
                 Canvas.DrawRectangle(new Position(0, offset - thickness / 2f), new Size(request.TextSize.Width, thickness), Style.Color);
             }
+        }
+
+        private static Position GetGlyphOffsetForStyle(TextStyle style)
+        {
+            if (style.FontVariant == FontVariant.Superscript)
+                return new Position(0, (style.Size ?? 12f) * -0.35f);
+            if (style.FontVariant == FontVariant.Subscript)
+                return new Position(0, (style.Size ?? 12f) * 0.1f);
+
+            return Position.Zero;
         }
     }
 }

--- a/QuestPDF/Elements/Text/Items/TextBlockSpan.cs
+++ b/QuestPDF/Elements/Text/Items/TextBlockSpan.cs
@@ -74,25 +74,25 @@ namespace QuestPDF.Elements.Text.Items
         {
             var fontMetrics = Style.ToFontMetrics();
 
+            var glyphOffsetY = GetVerticalGlyphOffsetForStyle(Style);
+
             Canvas.DrawRectangle(new Position(0, request.TotalAscent), new Size(request.TextSize.Width, request.TextSize.Height), Style.BackgroundColor);
 
             if (!string.IsNullOrWhiteSpace(Text))
             {
-                var offset = GetGlyphOffsetForStyle(Style);
-
                 if (RequiresShaping)
-                    Canvas.DrawShapedText(Text, offset, Style);
+                    Canvas.DrawShapedText(Text, new Position(0, glyphOffsetY), Style);
                 else
-                    Canvas.DrawText(Text, offset, Style);
+                    Canvas.DrawText(Text, new Position(0, glyphOffsetY), Style);
             }
 
             // draw underline
             if ((Style.HasUnderline ?? false) && fontMetrics.UnderlinePosition.HasValue)
-                DrawLine(fontMetrics.UnderlinePosition.Value, fontMetrics.UnderlineThickness ?? 1);
+                DrawLine(glyphOffsetY + fontMetrics.UnderlinePosition.Value, fontMetrics.UnderlineThickness ?? 1);
             
             // draw stroke
             if ((Style.HasStrikethrough ?? false) && fontMetrics.StrikeoutPosition.HasValue)
-                DrawLine(fontMetrics.StrikeoutPosition.Value, fontMetrics.StrikeoutThickness ?? 1);
+                DrawLine(glyphOffsetY + fontMetrics.StrikeoutPosition.Value, fontMetrics.StrikeoutThickness ?? 1);
 
             void DrawLine(float offset, float thickness)
             {
@@ -100,14 +100,14 @@ namespace QuestPDF.Elements.Text.Items
             }
         }
 
-        private static Position GetGlyphOffsetForStyle(TextStyle style)
+        private static float GetVerticalGlyphOffsetForStyle(TextStyle style)
         {
             if (style.FontVariant == FontVariant.Superscript)
-                return new Position(0, (style.Size ?? 12f) * -0.35f);
+                return (style.Size ?? 12f) * -0.35f;
             if (style.FontVariant == FontVariant.Subscript)
-                return new Position(0, (style.Size ?? 12f) * 0.1f);
+                return (style.Size ?? 12f) * 0.1f;
 
-            return Position.Zero;
+            return 0;
         }
     }
 }

--- a/QuestPDF/Elements/Text/Items/TextBlockSpan.cs
+++ b/QuestPDF/Elements/Text/Items/TextBlockSpan.cs
@@ -29,7 +29,7 @@ namespace QuestPDF.Elements.Text.Items
         private TextBlockSize GetSizeForWord()
         {
             var paint = Style.ToPaint();
-            var fontMetrics = Style.ToFontMetrics();
+            var fontMetrics = Style.ToNormalizedFontMetrics();
 
             var shaper = Style.ToShaper();
             

--- a/QuestPDF/Fluent/TextStyleExtensions.cs
+++ b/QuestPDF/Fluent/TextStyleExtensions.cs
@@ -109,7 +109,29 @@ namespace QuestPDF.Fluent
         {
             return style.Weight(FontWeight.ExtraBlack);
         }
-        
+
+        #endregion
+
+        #region Variant
+        public static TextStyle Variant(this TextStyle style, FontVariant variant)
+        {
+            return style.Mutate(x => x.FontVariant = variant);
+        }
+
+        public static TextStyle NormalVariant(this TextStyle style)
+        {
+            return style.Variant(FontVariant.Normal);
+        }
+
+        public static TextStyle Subscript(this TextStyle style)
+        {
+            return style.Variant(FontVariant.Subscript);
+        }
+
+        public static TextStyle Superscript(this TextStyle style)
+        {
+            return style.Variant(FontVariant.Superscript);
+        }
         #endregion
     }
 }

--- a/QuestPDF/Infrastructure/FontVariant.cs
+++ b/QuestPDF/Infrastructure/FontVariant.cs
@@ -1,0 +1,9 @@
+﻿namespace QuestPDF.Infrastructure
+{
+  public enum FontVariant
+  {
+    Normal = 0,
+    Subscript,
+    Superscript,
+  }
+}

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -20,6 +20,8 @@ namespace QuestPDF.Infrastructure
 
         internal object PaintKey { get; private set; }
         internal object FontMetricsKey { get; private set; }
+
+        internal object NormalizedFontMetricsKey => (FontType, Size, FontWeight, Infrastructure.FontVariant.Normal, IsItalic);
         
         internal static TextStyle LibraryDefault => new TextStyle
         {

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -13,6 +13,7 @@ namespace QuestPDF.Infrastructure
         internal float? Size { get; set; }
         internal float? LineHeight { get; set; }
         internal FontWeight? FontWeight { get; set; }
+        internal FontVariant? FontVariant { get; set; }
         internal bool? IsItalic { get; set; }
         internal bool? HasStrikethrough { get; set; }
         internal bool? HasUnderline { get; set; }
@@ -28,6 +29,7 @@ namespace QuestPDF.Infrastructure
             Size = 12,
             LineHeight = 1.2f,
             FontWeight = Infrastructure.FontWeight.Normal,
+            FontVariant = Infrastructure.FontVariant.Normal,
             IsItalic = false,
             HasStrikethrough = false,
             HasUnderline = false
@@ -43,8 +45,8 @@ namespace QuestPDF.Infrastructure
             HasGlobalStyleApplied = true;
 
             ApplyParentStyle(globalStyle);
-            PaintKey ??= (FontType, Size, FontWeight, IsItalic, Color);
-            FontMetricsKey ??= (FontType, Size, FontWeight, IsItalic);
+            PaintKey ??= (FontType, Size, FontWeight, FontVariant, IsItalic, Color);
+            FontMetricsKey ??= (FontType, Size, FontWeight, FontVariant, IsItalic);
         }
         
         internal void ApplyParentStyle(TextStyle parentStyle)
@@ -55,6 +57,7 @@ namespace QuestPDF.Infrastructure
             Size ??= parentStyle.Size;
             LineHeight ??= parentStyle.LineHeight;
             FontWeight ??= parentStyle.FontWeight;
+            FontVariant ??= parentStyle.FontVariant;
             IsItalic ??= parentStyle.IsItalic;
             HasStrikethrough ??= parentStyle.HasStrikethrough;
             HasUnderline ??= parentStyle.HasUnderline;


### PR DESCRIPTION
i have gone ahead and implemented subscript and superscript text. This is based on the implementation from [this repository](https://github.com/toptensoftware/RichTextKit), which also uses skia to render all types of text.

Should fix #104 

You mentioned in a discussion that you want to rework the way text is rendered, so i dont know if this is the right time/branch to submit this. Hopefully this pull request does at least give an idea on how to implement such feature. 