### PR TITLE
Replaced PageEnd with PageStart in PageNumberWithinSection

### DIFF
--- a/QuestPDF/Fluent/TextExtensions.cs
+++ b/QuestPDF/Fluent/TextExtensions.cs
@@ -174,7 +174,7 @@ namespace QuestPDF.Fluent
         
         public TextPageNumberDescriptor PageNumberWithinSection(string locationName)
         {
-            return PageNumber(x => x.CurrentPage + 1 - x.GetLocation(locationName)?.PageEnd);
+            return PageNumber(x => x.CurrentPage + 1 - x.GetLocation(locationName)?.PageStart);
         }
         
         public TextPageNumberDescriptor TotalPagesWithinSection(string locationName)


### PR DESCRIPTION
The page count within a section should use the start page of the section instead of the end.

If a section starts in page 2 and it has the end in page 5 of the document current method uses:
2 (CurrentPage) + 1 - 5 (GetLocation(...).PageEnd) = -2

With PageStart the result is 2 (2 + 1 - 2)