### PR TITLE
replace obsolete method in readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Document.Create(container =>
     {
         page.Size(PageSizes.A4);
         page.Margin(2, Unit.Centimetre);
-        page.Background(Colors.White);
+        page.PageColor(Colors.White);
         page.DefaultTextStyle(x => x.FontSize(20));
         
         page.Header()


### PR DESCRIPTION
Warning	CS0618	'PageDescriptor.Background(string)' is obsolete: 'This element has been renamed since version 2022.3. Please use the PageColor method.'