### PR TITLE
Reduce creation of new arrays in Queue<T>

### DIFF
--- a/QuestPDF/Elements/Table/Table.cs
+++ b/QuestPDF/Elements/Table/Table.cs
@@ -42,7 +42,9 @@ namespace QuestPDF.Elements.Table
 
         public void ResetState()
         {
-            Cells.ForEach(x => x.IsRendered = false);
+            foreach (var x in Cells)
+                x.IsRendered = false;
+            
             CurrentRow = 1;
         }
 

--- a/QuestPDF/Elements/Text/TextBlock.cs
+++ b/QuestPDF/Elements/Text/TextBlock.cs
@@ -20,7 +20,20 @@ namespace QuestPDF.Elements.Text
 
         public void ResetState()
         {
-            RenderingQueue = new Queue<ITextBlockItem>(Items);
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            // Create queue when we don't have one yet, otherwise clear the existing one so it re-uses the internal array under the hood.
+            if (RenderingQueue == null)
+            {
+                RenderingQueue = new Queue<ITextBlockItem>(Items);
+            }
+            else
+            {
+                RenderingQueue.Clear();
+            
+                foreach (var item in Items)
+                    RenderingQueue.Enqueue(item);
+            }
+            
             CurrentElementIndex = 0;
         }
 


### PR DESCRIPTION
Some blocking garbage collection is caused by newing up a `Queue` here. 

If you check the source code of the `Queue` constructor. ([find it here on GitHub](https://github.com/dotnet/runtime/blob/release/6.0/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs#L57)), every time a new `Queue` is instantiated, a new array is allocated with a copy of all references in `Items`. All of these arrays have to be garbage collected as well.

The `Queue` class has a `Clear()` method as well, which does not allocate a new array but instead [clears the current one](https://github.com/dotnet/runtime/blob/release/6.0/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Queue.cs#L74) by setting all values to `null`.

This avoids excessive GC in the table benchmark.