### PR TITLE
Re-use static variable instead of method call in TextStyle

### DIFF
--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -22,7 +22,10 @@ namespace QuestPDF.Infrastructure
         internal object PaintKey { get; private set; }
         internal object FontMetricsKey { get; private set; }
         
-        internal static TextStyle LibraryDefault => new TextStyle
+        // REVIEW: Should this be a method call that news up a TextStyle,
+        // or can it be a static variable?
+        // (style mutations seem to create a clone anyway)
+        internal static readonly TextStyle LibraryDefault = new TextStyle
         {
             Color = Colors.Black,
             BackgroundColor = Colors.Transparent,
@@ -37,7 +40,10 @@ namespace QuestPDF.Infrastructure
             WrapAnywhere = false
         };
 
-        public static TextStyle Default => new TextStyle();
+        // REVIEW: Should this be a method call that news up a TextStyle,
+        // or can it be a static variable?
+        // (style mutations seem to create a clone anyway)
+        public static readonly TextStyle Default = new TextStyle();
         
         internal void ApplyGlobalStyle(TextStyle globalStyle)
         {


### PR DESCRIPTION
Since `TextStyle` is copied anyway, why not have the default styles as a static variable instead of newing up one every time it is needed... This change reduces the amount of gen0 collections and boosts general performance of the table benchmark a bit.