### PR TITLE
Remove some casts on hot path by using .Count == 0 instead of .Any()

### DIFF
--- a/QuestPDF.Previewer/InteractiveCanvas.cs
+++ b/QuestPDF.Previewer/InteractiveCanvas.cs
@@ -26,7 +26,7 @@ class InteractiveCanvas : ICustomDrawOperation
 
     public float TotalPagesHeight => Pages.Sum(x => x.Height) + (Pages.Count - 1) * PageSpacing;
     public float TotalHeight => TotalPagesHeight + SafeZone * 2 / Scale;
-    public float MaxWidth => Pages.Any() ? Pages.Max(x => x.Width) : 0;
+    public float MaxWidth => Pages.Count > 0 ? Pages.Max(x => x.Width) : 0;
     
     public float MaxTranslateY => TotalHeight - Height / Scale;
 

--- a/QuestPDF/Drawing/Proxy/DebuggingState.cs
+++ b/QuestPDF/Drawing/Proxy/DebuggingState.cs
@@ -38,7 +38,7 @@ namespace QuestPDF.Drawing.Proxy
 
             Root ??= item;
             
-            if (Stack.Any())
+            if (Stack.Count > 0)
                 Stack.Peek().Stack.Add(item);
 
             Stack.Push(item);

--- a/QuestPDF/Elements/Column.cs
+++ b/QuestPDF/Elements/Column.cs
@@ -41,12 +41,12 @@ namespace QuestPDF.Elements
 
         internal override SpacePlan Measure(Size availableSpace)
         {
-            if (!Items.Any())
+            if (Items.Count == 0)
                 return SpacePlan.FullRender(Size.Zero);
             
             var renderingCommands = PlanLayout(availableSpace);
 
-            if (!renderingCommands.Any())
+            if (renderingCommands.Count == 0)
                 return SpacePlan.Wrap();
 
             var width = renderingCommands.Max(x => x.Size.Width);

--- a/QuestPDF/Elements/Grid.cs
+++ b/QuestPDF/Elements/Grid.cs
@@ -31,7 +31,7 @@ namespace QuestPDF.Elements
             {
                 column.Spacing(VerticalSpacing);
                 
-                while (ChildrenQueue.Any())
+                while (ChildrenQueue.Count > 0)
                     column.Item().Row(BuildRow);
             });
         }
@@ -40,7 +40,7 @@ namespace QuestPDF.Elements
         {
             var rowLength = 0;
                 
-            while (ChildrenQueue.Any())
+            while (ChildrenQueue.Count > 0)
             {
                 var element = ChildrenQueue.Peek();
                             

--- a/QuestPDF/Elements/Inlined.cs
+++ b/QuestPDF/Elements/Inlined.cs
@@ -43,12 +43,12 @@ namespace QuestPDF.Elements
         
         internal override SpacePlan Measure(Size availableSpace)
         {
-            if (!ChildrenQueue.Any())
+            if (ChildrenQueue.Count == 0)
                 return SpacePlan.FullRender(Size.Zero);
             
             var lines = Compose(availableSpace);
 
-            if (!lines.Any())
+            if (lines.Count == 0)
                 return SpacePlan.Wrap();
 
             var lineSizes = lines
@@ -189,7 +189,7 @@ namespace QuestPDF.Elements
             {
                 var line = GetNextLine();
                 
-                if (!line.Any())
+                if (line.Count == 0)
                     break;
 
                 var height = line
@@ -213,7 +213,7 @@ namespace QuestPDF.Elements
                 
                 while (true)
                 {
-                    if (!queue.Any())
+                    if (queue.Count == 0)
                         break;
                     
                     var element = queue.Peek();

--- a/QuestPDF/Elements/Row.cs
+++ b/QuestPDF/Elements/Row.cs
@@ -53,7 +53,7 @@ namespace QuestPDF.Elements
 
         internal override SpacePlan Measure(Size availableSpace)
         {
-            if (!Items.Any())
+            if (Items.Count == 0)
                 return SpacePlan.FullRender(Size.Zero);
             
             UpdateItemsWidth(availableSpace.Width);
@@ -77,7 +77,7 @@ namespace QuestPDF.Elements
 
         internal override void Draw(Size availableSpace)
         {
-            if (!Items.Any())
+            if (Items.Count == 0)
                 return;
 
             UpdateItemsWidth(availableSpace.Width);

--- a/QuestPDF/Elements/Table/Table.cs
+++ b/QuestPDF/Elements/Table/Table.cs
@@ -73,13 +73,13 @@ namespace QuestPDF.Elements.Table
         
         internal override SpacePlan Measure(Size availableSpace)
         {
-            if (!Cells.Any())
+            if (Cells.Count == 0)
                 return SpacePlan.FullRender(Size.Zero);
             
             UpdateColumnsWidth(availableSpace.Width);
             var renderingCommands = PlanLayout(availableSpace);
 
-            if (!renderingCommands.Any())
+            if (renderingCommands.Count == 0)
                 return SpacePlan.Wrap();
             
             var width = Columns.Sum(x => x.Width);
@@ -149,7 +149,7 @@ namespace QuestPDF.Elements.Table
             
             var commands = GetRenderingCommands();
 
-            if (!commands.Any())
+            if (commands.Count == 0)
                 return commands;
             
             var tableHeight = commands.Max(cell => cell.Offset.Y + cell.Size.Height);
@@ -238,7 +238,7 @@ namespace QuestPDF.Elements.Table
                     });
                 }
 
-                if (!commands.Any())
+                if (commands.Count == 0)
                     return commands;
 
                 var maxRow = commands.Select(x => x.Cell).Max(x => x.Row + x.RowSpan);

--- a/QuestPDF/Elements/Text/TextBlock.cs
+++ b/QuestPDF/Elements/Text/TextBlock.cs
@@ -26,12 +26,12 @@ namespace QuestPDF.Elements.Text
 
         internal override SpacePlan Measure(Size availableSpace)
         {
-            if (!RenderingQueue.Any())
+            if (RenderingQueue.Count == 0)
                 return SpacePlan.FullRender(Size.Zero);
             
             var lines = DivideTextItemsIntoLines(availableSpace.Width, availableSpace.Height).ToList();
 
-            if (!lines.Any())
+            if (lines.Count == 0)
                 return SpacePlan.Wrap();
             
             var width = lines.Max(x => x.Width);
@@ -55,7 +55,7 @@ namespace QuestPDF.Elements.Text
         {
             var lines = DivideTextItemsIntoLines(availableSpace.Width, availableSpace.Height).ToList();
             
-            if (!lines.Any())
+            if (lines.Count == 0)
                 return;
             
             var heightOffset = 0f;
@@ -110,7 +110,7 @@ namespace QuestPDF.Elements.Text
             var lastElementMeasurement = lines.Last().Elements.Last().Measurement;
             CurrentElementIndex = lastElementMeasurement.IsLast ? 0 : lastElementMeasurement.EndIndex;
             
-            if (!RenderingQueue.Any())
+            if (RenderingQueue.Count == 0)
                 ResetState();
             
             float GetAlignmentOffset(float lineWidth)
@@ -136,11 +136,11 @@ namespace QuestPDF.Elements.Text
             var currentItemIndex = CurrentElementIndex;
             var currentHeight = 0f;
 
-            while (queue.Any())
+            while (queue.Count > 0)
             {
                 var line = GetNextLine();
                 
-                if (!line.Elements.Any())
+                if (line.Elements.Count == 0)
                     yield break;
                 
                 if (currentHeight + line.LineHeight > availableHeight + Size.Epsilon)
@@ -158,7 +158,7 @@ namespace QuestPDF.Elements.Text
             
                 while (true)
                 {
-                    if (!queue.Any())
+                    if (queue.Count == 0)
                         break;
 
                     var currentElement = queue.Peek();
@@ -172,7 +172,7 @@ namespace QuestPDF.Elements.Text
                         AvailableWidth = availableWidth - currentWidth,
                         
                         IsFirstElementInBlock = currentElement == Items.First(),
-                        IsFirstElementInLine = !currentLineElements.Any()
+                        IsFirstElementInLine = currentLineElements.Count == 0
                     };
                 
                     var measurementResponse = currentElement.Measure(measurementRequest);

--- a/QuestPDF/Fluent/TableExtensions.cs
+++ b/QuestPDF/Fluent/TableExtensions.cs
@@ -111,7 +111,7 @@ namespace QuestPDF.Fluent
 
         private static void ConfigureTable(Table table)
         {
-            if (!table.Columns.Any())
+            if (table.Columns.Count == 0)
                 throw new DocumentComposeException($"Table should have at least one column. Please call the '{nameof(ColumnsDefinition)}' method to define columns.");
             
             table.PlanCellPositions();

--- a/QuestPDF/Fluent/TextExtensions.cs
+++ b/QuestPDF/Fluent/TextExtensions.cs
@@ -77,7 +77,7 @@ namespace QuestPDF.Fluent
 
         private void AddItemToLastTextBlock(ITextBlockItem item)
         {
-            if (!TextBlocks.Any())
+            if (TextBlocks.Count == 0)
                 TextBlocks.Add(new TextBlock());
             
             TextBlocks.Last().Items.Add(item);


### PR DESCRIPTION
`.Any()` creates new iterators and all, for nothing. A simple `.Count == 0` does not need to allocate, boosting the general performance of the table benchmark a bit.