### PR TITLE
Reduce size of TextStyle and use strings to cache them in the render stage

### DIFF
--- a/QuestPDF/Drawing/FontManager.cs
+++ b/QuestPDF/Drawing/FontManager.cs
@@ -11,8 +11,8 @@ namespace QuestPDF.Drawing
     public static class FontManager
     {
         private static ConcurrentDictionary<string, FontStyleSet> StyleSets = new();
-        private static ConcurrentDictionary<object, SKFontMetrics> FontMetrics = new();
-        private static ConcurrentDictionary<object, SKPaint> Paints = new();
+        private static ConcurrentDictionary<int, SKFontMetrics> FontMetrics = new();
+        private static ConcurrentDictionary<int, SKPaint> Paints = new();
         private static ConcurrentDictionary<string, SKPaint> ColorPaint = new();
 
         private static void RegisterFontType(SKData fontData, string? customName = null)

--- a/QuestPDF/Drawing/FontManager.cs
+++ b/QuestPDF/Drawing/FontManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using QuestPDF.Fluent;
 using QuestPDF.Infrastructure;
 using SkiaSharp;
@@ -11,8 +12,8 @@ namespace QuestPDF.Drawing
     public static class FontManager
     {
         private static ConcurrentDictionary<string, FontStyleSet> StyleSets = new();
-        private static ConcurrentDictionary<int, SKFontMetrics> FontMetrics = new();
-        private static ConcurrentDictionary<int, SKPaint> Paints = new();
+        private static ConcurrentDictionary<string, SKFontMetrics> FontMetrics = new();
+        private static ConcurrentDictionary<string, SKPaint> Paints = new();
         private static ConcurrentDictionary<string, SKPaint> ColorPaint = new();
 
         private static void RegisterFontType(SKData fontData, string? customName = null)
@@ -61,7 +62,7 @@ namespace QuestPDF.Drawing
 
         internal static SKPaint ToPaint(this TextStyle style)
         {
-            return Paints.GetOrAdd(style.PaintKey, key => Convert(style));
+            return Paints.GetOrAdd(CalculatePaintKey(style), key => Convert(style));
 
             static SKPaint Convert(TextStyle style)
             {
@@ -120,7 +121,19 @@ namespace QuestPDF.Drawing
 
         internal static SKFontMetrics ToFontMetrics(this TextStyle style)
         {
-            return FontMetrics.GetOrAdd(style.FontMetricsKey, key => style.NormalPosition().ToPaint().FontMetrics);
+            return FontMetrics.GetOrAdd(CalculateFontMetricsKey(style), key => style.NormalPosition().ToPaint().FontMetrics);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string CalculatePaintKey(TextStyle style)
+        {
+            return $"{style.FontFamily}|{style.Size}|{style.FontWeight}|{style.FontPosition}|{style.IsItalic}|{style.Color}";
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string CalculateFontMetricsKey(TextStyle style)
+        {
+            return $"{style.FontFamily}|{style.Size}|{style.FontWeight}|{style.IsItalic}";
         }
     }
 }

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using QuestPDF.Helpers;
+﻿using QuestPDF.Helpers;
 
 namespace QuestPDF.Infrastructure
 {
@@ -18,37 +17,6 @@ namespace QuestPDF.Infrastructure
         internal bool? HasStrikethrough { get; set; }
         internal bool? HasUnderline { get; set; }
         internal bool? WrapAnywhere { get; set; }
-
-        internal int PaintKey
-        {
-            get
-            {
-                unchecked
-                {
-                    var hashCode = Color?.GetHashCode() ?? 0;
-                    hashCode = (hashCode * 397) ^ (FontFamily?.GetHashCode() ?? 0);
-                    hashCode = (hashCode * 397) ^ (Size?.GetHashCode() ?? 0);
-                    hashCode = (hashCode * 397) ^ (FontWeight?.GetHashCode() ?? 0);
-                    hashCode = (hashCode * 397) ^ (FontPosition?.GetHashCode() ?? 0);
-                    hashCode = (hashCode * 397) ^ (IsItalic?.GetHashCode() ?? 0);
-                    return hashCode;
-                }
-            }
-        }
-        internal int FontMetricsKey
-        {
-            get
-            {
-                unchecked
-                {
-                    var hashCode = (FontFamily?.GetHashCode() ?? 0);
-                    hashCode = (hashCode * 397) ^ (Size?.GetHashCode() ?? 0);
-                    hashCode = (hashCode * 397) ^ (FontWeight?.GetHashCode() ?? 0);
-                    hashCode = (hashCode * 397) ^ (IsItalic?.GetHashCode() ?? 0);
-                    return hashCode;
-                }
-            }
-        }
         
         internal static TextStyle LibraryDefault => new TextStyle
         {

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -19,8 +19,36 @@ namespace QuestPDF.Infrastructure
         internal bool? HasUnderline { get; set; }
         internal bool? WrapAnywhere { get; set; }
 
-        internal object PaintKey { get; private set; }
-        internal object FontMetricsKey { get; private set; }
+        internal int PaintKey
+        {
+            get
+            {
+                unchecked
+                {
+                    var hashCode = Color?.GetHashCode() ?? 0;
+                    hashCode = (hashCode * 397) ^ (FontFamily?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ (Size?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ (FontWeight?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ (FontPosition?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ (IsItalic?.GetHashCode() ?? 0);
+                    return hashCode;
+                }
+            }
+        }
+        internal int FontMetricsKey
+        {
+            get
+            {
+                unchecked
+                {
+                    var hashCode = (FontFamily?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ (Size?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ (FontWeight?.GetHashCode() ?? 0);
+                    hashCode = (hashCode * 397) ^ (IsItalic?.GetHashCode() ?? 0);
+                    return hashCode;
+                }
+            }
+        }
         
         internal static TextStyle LibraryDefault => new TextStyle
         {
@@ -47,8 +75,6 @@ namespace QuestPDF.Infrastructure
             HasGlobalStyleApplied = true;
 
             ApplyParentStyle(globalStyle);
-            PaintKey ??= (FontFamily, Size, FontWeight, FontPosition, IsItalic, Color);
-            FontMetricsKey ??= (FontFamily, Size, FontWeight, IsItalic);
         }
         
         internal void ApplyParentStyle(TextStyle parentStyle)


### PR DESCRIPTION
Reduces the size of TextStyle to reduce memory footprint in the table benchmark. Also speeds up GC by moving the cache key calculation into the render stage, and using simple strings instead of the `ValueTuple` that was originally created.