### PR TITLE
Fix default font name in TextStyle

### DIFF
--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Runtime.InteropServices;
 using QuestPDF.Helpers;
 using SkiaSharp;
 

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using QuestPDF.Helpers;
+using SkiaSharp;
 
 namespace QuestPDF.Infrastructure
 {
@@ -93,19 +94,8 @@ namespace QuestPDF.Infrastructure
             //taken from https://fontsarena.com/blog/operating-systems-default-sans-serif-fonts/
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return Fonts.Calibri;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "San Francisco";
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                var description = RuntimeInformation.OSDescription;
-                if (description?.ToLower().Contains("ubuntu") == true)
-                    return "Ubuntu";
-                if (description?.ToLower().Contains("red hat") == true)
-                    return "Red Hat";
-                if (description?.ToLower().Contains("debian") == true)
-                    return "DejaVu Sans";
-                return "Liberation Sans";
-            }
-
-            return "Sans Serif";
+            
+            return SKTypeface.FromFamilyName("Sans")?.FamilyName ?? SKTypeface.Default.FamilyName;
         }
     }
 }

--- a/QuestPDF/Infrastructure/TextStyle.cs
+++ b/QuestPDF/Infrastructure/TextStyle.cs
@@ -26,7 +26,7 @@ namespace QuestPDF.Infrastructure
         {
             Color = Colors.Black,
             BackgroundColor = Colors.Transparent,
-            FontFamily = Fonts.Calibri,
+            FontFamily = GetDefaultFontFamily(),
             Size = 12,
             LineHeight = 1.2f,
             FontWeight = Infrastructure.FontWeight.Normal,
@@ -86,6 +86,26 @@ namespace QuestPDF.Infrastructure
             var clone = (TextStyle)MemberwiseClone();
             clone.HasGlobalStyleApplied = false;
             return clone;
+        }
+        
+        private static string? GetDefaultFontFamily()
+        {
+            //taken from https://fontsarena.com/blog/operating-systems-default-sans-serif-fonts/
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return Fonts.Calibri;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "San Francisco";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var description = RuntimeInformation.OSDescription;
+                if (description?.ToLower().Contains("ubuntu") == true)
+                    return "Ubuntu";
+                if (description?.ToLower().Contains("red hat") == true)
+                    return "Red Hat";
+                if (description?.ToLower().Contains("debian") == true)
+                    return "DejaVu Sans";
+                return "Liberation Sans";
+            }
+
+            return "Sans Serif";
         }
     }
 }


### PR DESCRIPTION
This fix tries to fix error with absent `Calibri` font on non-Windows operating system:

```
The typeface 'Calibri' could not be found. Please consider the following options: 1) install the font on your operating system or execution environment. 2) load a font file specifically for QuestPDF usage via the QuestPDF.Drawing.FontManager.RegisterFontType(Stream fileContentStream) static method
```

It checks current environment and uses different font names for different operating systems. Some font names were taken from https://fontsarena.com/blog/operating-systems-default-sans-serif-fonts/, some were obtained during experiments. So, no guarantee that specified fonts are present on target systems (especially in linux), but it should be better than now. In Linux it takes first registered "Sans" font

The related issues are #267 and #132 
