### PR TITLE
Fix documentation link for previewer

### DIFF
--- a/QuestPDF.Previewer/PreviewerWindowViewModel.cs
+++ b/QuestPDF.Previewer/PreviewerWindowViewModel.cs
@@ -49,7 +49,7 @@ namespace QuestPDF.Previewer
             CommunicationService.Instance.OnDocumentRefreshed += HandleUpdatePreview;
             
             ShowPdfCommand = ReactiveCommand.Create(ShowPdf);
-            ShowDocumentationCommand = ReactiveCommand.Create(() => OpenLink("https://www.questpdf.com/documentation/api-reference.html"));
+            ShowDocumentationCommand = ReactiveCommand.Create(() => OpenLink("https://www.questpdf.com/api-reference/index.html"));
             SponsorProjectCommand = ReactiveCommand.Create(() => OpenLink("https://github.com/sponsors/QuestPDF"));
         }
 


### PR DESCRIPTION
Since the documentation was reworked the route for the `API Reference` has changed.
However the `Show documentation` button still links to the old route -> 404.

![image](https://user-images.githubusercontent.com/53836821/185909936-dd467c56-b3ef-42ba-a102-ba2eea7ad987.png)
