### PR TITLE
Previewer minimum package upgrade to work on Mac M1 Pro

### DIFF
--- a/QuestPDF.Previewer/QuestPDF.Previewer.csproj
+++ b/QuestPDF.Previewer/QuestPDF.Previewer.csproj
@@ -42,14 +42,14 @@
     
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Avalonia" Version="0.10.10" />
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.10" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.10" />
-        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="0.10.10" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.10" />
+        <PackageReference Include="Avalonia" Version="0.10.11" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.11" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.11" />
+        <PackageReference Include="Avalonia.Markup.Xaml.Loader" Version="0.10.11" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.11" />
         <PackageReference Include="ReactiveUI" Version="17.1.50" />
-        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.80.4" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.0" />
         <PackageReference Include="System.Reactive" Version="5.0.0" />
-        <PackageReference Include="SkiaSharp" Version="2.80.4" />
+        <PackageReference Include="SkiaSharp" Version="2.88.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix for issue #334 

Update Avalonia packages from `0.10.10` to `0.10.11`, and include the required SkiaSharp upgrades.
The packages could possibly be updated to the most current version but I didn't want to introduce any new issues.
This allows the Previewer to run on an M1 Pro (And possibly any other M1 macs, I don't have the hardware to test this)