### PR TITLE
Relative calculations

### DIFF
--- a/QuestPDF.Examples/RelativePositionExamples.cs
+++ b/QuestPDF.Examples/RelativePositionExamples.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using QuestPDF.Examples.Engine;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+
+namespace QuestPDF.Examples
+{
+    public class RelativePositionExamples
+    {
+        [Test]
+        public void ItemTypes()
+        {
+            RenderingTest
+                .Create()
+                .ProduceImages()
+                .PageSize(500, 500)
+                .ShowResults()
+                .Render(container =>
+                {
+                    container
+                        .Padding(100)
+                        .Background(Colors.Grey.Lighten2)
+                        .RelativePositionVertical(0.5f, -0.5f)
+                        .RelativePositionHorizontal(1f, -0.5f)
+                        .RelativeWidth(0.4f)
+                        .RelativeHeight(0.6f)
+                        .Background(Colors.Grey.Darken2);
+                });
+        }
+    }
+}

--- a/QuestPDF.Examples/RelativeSizeExamples.cs
+++ b/QuestPDF.Examples/RelativeSizeExamples.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using QuestPDF.Examples.Engine;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+
+namespace QuestPDF.Examples
+{
+    public class RelativeSizeExamples
+    {
+        [Test]
+        public void ItemTypes()
+        {
+            RenderingTest
+                .Create()
+                .ProduceImages()
+                .PageSize(600, 600)
+                .ShowResults()
+                .Render(container =>
+                {
+                    container
+                        .AlignMiddle()
+                        .AlignCenter()
+                        .Width(400)
+                        .Height(400)
+                        .Background(Colors.Grey.Lighten2)
+                        .AlignMiddle()
+                        .AlignCenter()
+                        .Container()
+                        .AlignMiddle()
+                        .AlignCenter()
+                        .RelativeWidth(0.25f)
+                        .RelativeHeight(0.5f)
+                        .Background(Colors.Grey.Darken2);
+                });
+        }
+    }
+}

--- a/QuestPDF/Elements/RelativePosition.cs
+++ b/QuestPDF/Elements/RelativePosition.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using QuestPDF.Drawing;
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.Elements
+{
+    internal class RelativePosition : ContainerElement
+    {
+        public float VerticalParent { get; set; }
+        public float VerticalSelf { get; set; }
+        
+        public float HorizontalParent { get; set; }
+        public float HorizontalSelf { get; set; } 
+        
+        internal override void Draw(Size availableSpace)
+        {
+            if (Child == null)
+                return;
+            
+            var childSize = base.Measure(availableSpace);
+            
+            if (childSize.Type == SpacePlanType.Wrap)
+                return;
+            
+            var left = availableSpace.Width * HorizontalParent + childSize.Width * HorizontalSelf;
+            var top = availableSpace.Height * VerticalParent + childSize.Height * VerticalSelf;
+
+            Canvas.Translate(new Position(left, top));
+            base.Draw(childSize);
+            Canvas.Translate(new Position(-left, -top));
+        }
+    }
+}

--- a/QuestPDF/Elements/RelativePosition.cs
+++ b/QuestPDF/Elements/RelativePosition.cs
@@ -7,10 +7,10 @@ namespace QuestPDF.Elements
     internal class RelativePosition : ContainerElement
     {
         public float VerticalParent { get; set; }
-        public float VerticalSelf { get; set; }
+        public float VerticalChild { get; set; }
         
         public float HorizontalParent { get; set; }
-        public float HorizontalSelf { get; set; } 
+        public float HorizontalChild { get; set; } 
         
         internal override void Draw(Size availableSpace)
         {
@@ -22,8 +22,8 @@ namespace QuestPDF.Elements
             if (childSize.Type == SpacePlanType.Wrap)
                 return;
             
-            var left = availableSpace.Width * HorizontalParent + childSize.Width * HorizontalSelf;
-            var top = availableSpace.Height * VerticalParent + childSize.Height * VerticalSelf;
+            var left = availableSpace.Width * HorizontalParent + childSize.Width * HorizontalChild;
+            var top = availableSpace.Height * VerticalParent + childSize.Height * VerticalChild;
 
             Canvas.Translate(new Position(left, top));
             base.Draw(childSize);

--- a/QuestPDF/Elements/RelativeSize.cs
+++ b/QuestPDF/Elements/RelativeSize.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using QuestPDF.Drawing;
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.Elements
+{
+    internal class RelativeSize : ContainerElement
+    {
+        public float? WidthFactor { get; set; } = 1f;
+        public float? HeightFactor { get; set; } = 1f;
+
+        internal override SpacePlan Measure(Size availableSpace)
+        {
+            var internalSpace = new Size(
+                availableSpace.Width * (WidthFactor ?? 1),
+                availableSpace.Height * (HeightFactor ?? 1));
+            
+            var childSpace = Child?.Measure(internalSpace) ?? SpacePlan.FullRender(0, 0);
+
+            if (childSpace.Type == SpacePlanType.Wrap)
+                return SpacePlan.Wrap();
+
+            var targetSpace = new Size(
+                WidthFactor.HasValue ? internalSpace.Width : childSpace.Width,
+                HeightFactor.HasValue ? internalSpace.Height : childSpace.Height);
+            
+            if (childSpace.Type == SpacePlanType.PartialRender)
+                return SpacePlan.PartialRender(targetSpace);
+            
+            if (childSpace.Type == SpacePlanType.FullRender)
+                return SpacePlan.FullRender(targetSpace);
+
+            throw new ArgumentException();
+        }
+    }
+}

--- a/QuestPDF/Fluent/RelativePositionExtensions.cs
+++ b/QuestPDF/Fluent/RelativePositionExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using QuestPDF.Elements;
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.Fluent
+{
+    public static class RelativePositionExtensions
+    {
+        private static IContainer RelativePosition(this IContainer element, Action<RelativePosition> handler)
+        {
+            var relativePosition = element as RelativePosition ?? new RelativePosition();
+            handler(relativePosition);
+            
+            return element.Element(relativePosition);
+        }
+
+        public static IContainer RelativePositionVertical(this IContainer element, float parentOffset, float selfOffset)
+        {
+            return element.RelativePosition(x =>
+            {
+                x.VerticalParent = parentOffset;
+                x.VerticalSelf = selfOffset;
+            });
+        }
+        
+        public static IContainer RelativePositionHorizontal(this IContainer element, float parentOffset, float selfOffset)
+        {
+            return element.RelativePosition(x =>
+            {
+                x.HorizontalParent = parentOffset;
+                x.HorizontalSelf = selfOffset;
+            });
+        }
+    }
+}

--- a/QuestPDF/Fluent/RelativePositionExtensions.cs
+++ b/QuestPDF/Fluent/RelativePositionExtensions.cs
@@ -14,21 +14,21 @@ namespace QuestPDF.Fluent
             return element.Element(relativePosition);
         }
 
-        public static IContainer RelativePositionVertical(this IContainer element, float parentOffset, float selfOffset)
+        public static IContainer RelativePositionVertical(this IContainer element, float parentOffset, float childOffset)
         {
             return element.RelativePosition(x =>
             {
                 x.VerticalParent = parentOffset;
-                x.VerticalSelf = selfOffset;
+                x.VerticalChild = childOffset;
             });
         }
         
-        public static IContainer RelativePositionHorizontal(this IContainer element, float parentOffset, float selfOffset)
+        public static IContainer RelativePositionHorizontal(this IContainer element, float parentOffset, float childOffset)
         {
             return element.RelativePosition(x =>
             {
                 x.HorizontalParent = parentOffset;
-                x.HorizontalSelf = selfOffset;
+                x.HorizontalChild = childOffset;
             });
         }
     }

--- a/QuestPDF/Fluent/RelativeSizeExtensions.cs
+++ b/QuestPDF/Fluent/RelativeSizeExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using QuestPDF.Elements;
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.Fluent
+{
+    public static class RelativeSizeExtensions
+    {
+        private static IContainer RelativeSize(this IContainer element, Action<RelativeSize> handler)
+        {
+            var relativeSize = element as RelativeSize ?? new RelativeSize();
+            handler(relativeSize);
+            
+            return element.Element(relativeSize);
+        }
+
+        public static IContainer RelativeWidth(this IContainer element, float value)
+        {
+            return element.RelativeSize(x => x.WidthFactor = value);
+        }
+        
+        public static IContainer RelativeHeight(this IContainer element, float value)
+        {
+            return element.RelativeSize(x => x.HeightFactor = value);
+        }
+    }
+}


### PR DESCRIPTION
# Rationale

Already existing positional elements provide general control over size and position. However, in some cases, more precise control is required. 

## Relative position

The `RelativePosition` element is a generalization of the `Alignment` element. Instead of using predefined positions (left, center, right, top, middle, bottom), it uses relative sizes of parent and its child.

This control is available in FluentAPI via two methods:

```csharp
public static IContainer RelativePositionVertical(this IContainer element, float parentOffset, float childOffset);
public static IContainer RelativePositionHorizontal(this IContainer element, float parentOffset, float childOffset);
```

Using all 4 paramerts, it is possible to achieve any relative positioning. Including already existing, basic cases:

| Type            | Parent offset | Child offset |
|-----------------|---------------|--------------|
| Left / Top      | 0             | 0            |
| Center / Middle | 0.5           | -0.5         |
| Right / Bottom  | 1             | -1           |

```csharp
.Width(500)
.Height(500)

.Padding(100)
.Background(Colors.Grey.Lighten1)

.RelativePositionVertical(0.5f, -0.5f)
.RelativePositionHorizontal(1f, -0.5f)

.Width(120)
.Height(160)

.Background(Colors.Grey.Darken2);
```