### PR TITLE
Replace type parameter text for Text

### DIFF
--- a/QuestPDF.Examples/DefaultTextStyleExamples.cs
+++ b/QuestPDF.Examples/DefaultTextStyleExamples.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using QuestPDF.Examples.Engine;
@@ -43,7 +44,7 @@ namespace QuestPDF.Examples
                                         .Height(50)
                                         .AlignCenter()
                                         .AlignMiddle()
-                                        .Text(i)
+                                        .Text(i.ToString(CultureInfo.InvariantCulture))
                                         .FontSize(16 + i / 4);   
                                 }
                             });

--- a/QuestPDF.Examples/DynamicOptimizedExample.cs
+++ b/QuestPDF.Examples/DynamicOptimizedExample.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using QuestPDF.Elements;
@@ -126,9 +127,9 @@ namespace QuestPDF.Examples
                         .Padding(5)
                         .Row(row =>
                         {
-                            row.ConstantItem(30).Text(index + 1);
+                            row.ConstantItem(30).Text((index + 1).ToString(CultureInfo.InvariantCulture));
                             row.RelativeItem().Text(item.ItemName);
-                            row.ConstantItem(50).AlignRight().Text(item.Count);
+                            row.ConstantItem(50).AlignRight().Text(item.Count.ToString(CultureInfo.InvariantCulture));
                             row.ConstantItem(50).AlignRight().Text($"{item.Price}$");
                             row.ConstantItem(50).AlignRight().Text($"{item.Count*item.Price}$");
                         });

--- a/QuestPDF.Examples/DynamicSimpleTableExample.cs
+++ b/QuestPDF.Examples/DynamicSimpleTableExample.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using QuestPDF.Elements;
@@ -96,9 +97,9 @@ namespace QuestPDF.Examples
                         {
                             var item = Items[index];
                                 
-                            table.Cell().Element(Style).Text(index + 1);
+                            table.Cell().Element(Style).Text((index + 1).ToString(CultureInfo.InvariantCulture));
                             table.Cell().Element(Style).Text(item.ItemName);
-                            table.Cell().Element(Style).AlignRight().Text(item.Count);
+                            table.Cell().Element(Style).AlignRight().Text(item.Count.ToString(CultureInfo.InvariantCulture));
                             table.Cell().Element(Style).AlignRight().Text($"{item.Price}$");
                             table.Cell().Element(Style).AlignRight().Text($"{item.Count*item.Price}$");
 

--- a/QuestPDF.Examples/TableExamples.cs
+++ b/QuestPDF.Examples/TableExamples.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using QuestPDF.Drawing;
@@ -389,12 +390,12 @@ namespace QuestPDF.Examples
                                 table.Cell().Element(CellStyle).ExtendHorizontal().AlignLeft().Text(page.name);
                                         
                                 // inches
-                                table.Cell().Element(CellStyle).Text(page.width);
-                                table.Cell().Element(CellStyle).Text(page.height);
+                                table.Cell().Element(CellStyle).Text(page.width.ToString(CultureInfo.InvariantCulture));
+                                table.Cell().Element(CellStyle).Text(page.height.ToString(CultureInfo.InvariantCulture));
                                         
                                 // points
-                                table.Cell().Element(CellStyle).Text(page.width * inchesToPoints);
-                                table.Cell().Element(CellStyle).Text(page.height * inchesToPoints);
+                                table.Cell().Element(CellStyle).Text((page.width * inchesToPoints).ToString(CultureInfo.InvariantCulture));
+                                table.Cell().Element(CellStyle).Text((page.height * inchesToPoints).ToString(CultureInfo.InvariantCulture));
                                         
                                 IContainer CellStyle(IContainer container) => DefaultCellStyle(container, Colors.White); 
                             }

--- a/QuestPDF.Examples/TextExamples.cs
+++ b/QuestPDF.Examples/TextExamples.cs
@@ -523,7 +523,7 @@ namespace QuestPDF.Examples
 
                         page.Content().Column(column =>
                         {
-                            column.Item().Text(null);
+                            column.Item().Text((string) null);
 
                             column.Item().Text(text =>
                             {
@@ -555,7 +555,7 @@ namespace QuestPDF.Examples
 
                         page.Content().Column(column =>
                         {
-                            column.Item().Text(null);
+                            column.Item().Text((string) null);
 
                             column.Item().Text(text =>
                             {

--- a/QuestPDF/Fluent/TextExtensions.cs
+++ b/QuestPDF/Fluent/TextExtensions.cs
@@ -281,11 +281,17 @@ namespace QuestPDF.Fluent
         {
             element.Text(text).Style(style);
         }
-        
+
+        [Obsolete("Please use an overload where the text parameter is passed explicitly as a string.")]
         public static TextSpanDescriptor Text(this IContainer element, object? text)
         {
-            var descriptor = (TextSpanDescriptor) null;
-            element.Text(x => descriptor = x.Span(text?.ToString()));
+            return element.Text(text?.ToString());
+        }
+
+        public static TextSpanDescriptor Text(this IContainer element, string? text)
+        {
+            var descriptor = (TextSpanDescriptor) null!;
+            element.Text(x => descriptor = x.Span(text));
             return descriptor;
         }
     }


### PR DESCRIPTION
In addition to reminding us to pass numbers in the right culture, we also keep our API safe from unexpected values. For example

`dotnet fsi example.fsx`
```fs
#r "nuget: QuestPDF, 2022.9.0"

open QuestPDF.Fluent
open QuestPDF.Helpers

let filename = "hello.pdf"

Document
    .Create(fun container ->
        container.Page(fun page ->
            page.Size(PageSizes.A10);
            page.Content()
                .AlignCenter()
                .Text(fun x ->
                    x.Span("Page ") |> ignore
                    x.CurrentPageNumber()) |> ignore)
                |> ignore)
    .GeneratePdf(filename)

System.Diagnostics.Process.Start("explorer", filename) |> ignore
```
![image](https://user-images.githubusercontent.com/2669927/194692780-54b1a7c9-d645-4c05-82aa-9395e4ed9292.png)


Closes #257