### PR TITLE
Merge documents

### DIFF
--- a/QuestPDF.Examples/Engine/RenderingTest.cs
+++ b/QuestPDF.Examples/Engine/RenderingTest.cs
@@ -109,7 +109,7 @@ namespace QuestPDF.Examples.Engine
             Render(document);
         }
         
-        private void Render(IDocument document)
+        public void Render(IDocument document)
         {
             if (ResultType == RenderingTestResult.Images)
             {

--- a/QuestPDF.Examples/MergeDocumentsExamples.cs
+++ b/QuestPDF.Examples/MergeDocumentsExamples.cs
@@ -30,7 +30,7 @@ namespace QuestPDF.Examples
                 CreateDocument("Document 1"),
                 CreateDocument("Document 2"),
                 CreateDocument("Document 3"))
-                .SeperatePageNumbers();
+                .SeparatePageNumbers();
 
             RenderingTest
                 .Create()

--- a/QuestPDF.Examples/MergeDocumentsExamples.cs
+++ b/QuestPDF.Examples/MergeDocumentsExamples.cs
@@ -1,0 +1,67 @@
+﻿using NUnit.Framework;
+using QuestPDF.Examples.Engine;
+using QuestPDF.Fluent;
+
+namespace QuestPDF.Examples
+{
+    [TestFixture]
+    public class MergeDocumentsExamples
+    {
+        [Test]
+        public void Merge_ContinousPageNumbers()
+        {
+            var mergedDocument = Document.Merge(
+                CreateDocument("Document 1"),
+                CreateDocument("Document 2"),
+                CreateDocument("Document 3"))
+                .ContinuousPageNumbers();
+
+            RenderingTest
+                .Create()
+                .ProducePdf()
+                .ShowResults()
+                .Render(mergedDocument);
+        }
+
+        [Test]
+        public void Merge_SeperatePageNumbers()
+        {
+            var mergedDocument = Document.Merge(
+                CreateDocument("Document 1"),
+                CreateDocument("Document 2"),
+                CreateDocument("Document 3"))
+                .SeperatePageNumbers();
+
+            RenderingTest
+                .Create()
+                .ProducePdf()
+                .ShowResults()
+                .Render(mergedDocument);
+        }
+
+
+        private static Document CreateDocument(string content)
+        {
+            return Document.Create(d =>
+            {
+                d.Page(p =>
+                {
+                    p.Content().AlignMiddle().AlignCenter().Column(c =>
+                    {
+                        c.Item().Text(content).FontSize(40);
+                        c.Item().PageBreak();
+                        c.Item().Text(content).FontSize(40);
+                    });
+
+                    p.Footer().AlignCenter().PaddingVertical(20).Text(t =>
+                    {
+                        t.CurrentPageNumber();
+                        t.Span(" / ");
+                        t.TotalPages();
+                    });
+                });
+            });
+        }
+
+    }
+}

--- a/QuestPDF/Drawing/DocumentGenerator.cs
+++ b/QuestPDF/Drawing/DocumentGenerator.cs
@@ -62,7 +62,7 @@ namespace QuestPDF.Drawing
             where TCanvas : ICanvas, IRenderingCanvas
         {
             if (document is MergedDocument mergedDocument
-             && mergedDocument.PageNumberHandling == MergedDocumentPageNumberHandling.Seperate)
+             && mergedDocument.PageNumberHandling == MergedDocumentPageNumberHandling.Separate)
             {
                 canvas.BeginDocument();
                 foreach (var singleDocument in mergedDocument.Documents)

--- a/QuestPDF/Fluent/MinimalApi.cs
+++ b/QuestPDF/Fluent/MinimalApi.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using QuestPDF.Drawing;
 using QuestPDF.Infrastructure;
 
@@ -17,6 +18,16 @@ namespace QuestPDF.Fluent
         public static Document Create(Action<IDocumentContainer> handler)
         {
             return new Document(handler);
+        }
+
+        public static IMergedDocument Merge(IEnumerable<IDocument> documents)
+        {
+            return new MergedDocument(documents);
+        }
+
+        public static IMergedDocument Merge(params IDocument[] documents)
+        {
+            return new MergedDocument(documents);
         }
 
         public Document WithMetadata(DocumentMetadata metadata)

--- a/QuestPDF/Infrastructure/IMergedDocument.cs
+++ b/QuestPDF/Infrastructure/IMergedDocument.cs
@@ -12,7 +12,7 @@ namespace QuestPDF.Infrastructure
         /// Page numbers will be reset after each document is generated.
         /// E.g. two documents with a page count of 2 and 3 will result in the following page numbers: 1,2,1,2,3.
         /// </summary>
-        IMergedDocument SeperatePageNumbers();
+        IMergedDocument SeparatePageNumbers();
 
         /// <summary>
         /// All documents should be treated as a 'single' document in terms of page numbering.
@@ -26,7 +26,7 @@ namespace QuestPDF.Infrastructure
 
     internal enum MergedDocumentPageNumberHandling
     {
-        Seperate,
+        Separate,
         Continuous,
     }
 
@@ -34,7 +34,7 @@ namespace QuestPDF.Infrastructure
     {
         public IReadOnlyList<IDocument> Documents { get; }
 
-        public MergedDocumentPageNumberHandling PageNumberHandling { get; private set; } = MergedDocumentPageNumberHandling.Seperate;
+        public MergedDocumentPageNumberHandling PageNumberHandling { get; private set; } = MergedDocumentPageNumberHandling.Separate;
         public DocumentMetadata Metadata { get; private set; } = DocumentMetadata.Default;
 
         public MergedDocument(IEnumerable<IDocument> documents)
@@ -55,9 +55,9 @@ namespace QuestPDF.Infrastructure
             return Metadata;
         }
 
-        public IMergedDocument SeperatePageNumbers()
+        public IMergedDocument SeparatePageNumbers()
         {
-            PageNumberHandling = MergedDocumentPageNumberHandling.Seperate;
+            PageNumberHandling = MergedDocumentPageNumberHandling.Separate;
             return this;
         }
 

--- a/QuestPDF/Infrastructure/IMergedDocument.cs
+++ b/QuestPDF/Infrastructure/IMergedDocument.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using QuestPDF.Drawing;
+
+namespace QuestPDF.Infrastructure
+{
+    public interface IMergedDocument : IDocument
+    {
+        /// <summary>
+        /// Each document should be treated as a 'single' one in terms of page numbering.
+        /// Page numbers will be reset after each document is generated.
+        /// E.g. two documents with a page count of 2 and 3 will result in the following page numbers: 1,2,1,2,3.
+        /// </summary>
+        IMergedDocument SeperatePageNumbers();
+
+        /// <summary>
+        /// All documents should be treated as a 'single' document in terms of page numbering.
+        /// Page numbers will continue to increase throughout the document generation.
+        /// E.g. two documents with a page count of 2 and 3 will result in the following page numbers: 1,2,3,4,5.
+        /// </summary>
+        IMergedDocument ContinuousPageNumbers();
+
+        IMergedDocument WithMetadata(DocumentMetadata metadata);
+    }
+
+    internal enum MergedDocumentPageNumberHandling
+    {
+        Seperate,
+        Continuous,
+    }
+
+    internal sealed class MergedDocument : IMergedDocument, IDocument
+    {
+        public IReadOnlyList<IDocument> Documents { get; }
+
+        public MergedDocumentPageNumberHandling PageNumberHandling { get; private set; } = MergedDocumentPageNumberHandling.Seperate;
+        public DocumentMetadata Metadata { get; private set; } = DocumentMetadata.Default;
+
+        public MergedDocument(IEnumerable<IDocument> documents)
+        {
+            Documents = documents?.ToList() ?? throw new NullReferenceException(nameof(documents));
+        }
+
+        public void Compose(IDocumentContainer container)
+        {
+            foreach (var document in Documents)
+            {
+                document.Compose(container);
+            }
+        }
+
+        public DocumentMetadata GetMetadata()
+        {
+            return Metadata;
+        }
+
+        public IMergedDocument SeperatePageNumbers()
+        {
+            PageNumberHandling = MergedDocumentPageNumberHandling.Seperate;
+            return this;
+        }
+
+        public IMergedDocument ContinuousPageNumbers()
+        {
+            PageNumberHandling = MergedDocumentPageNumberHandling.Continuous;
+            return this;
+        }
+
+        public IMergedDocument WithMetadata(DocumentMetadata metadata)
+        {
+            Metadata = metadata ?? Metadata;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This pull request makes it possible to combine multiple QuestPDF documents into a single one.
Motivation: Combining multiple reports into a single file without the usage of PDF merging tools like PDFSharp.

Code sample:

```csharp
var doc1 = Document.Create(...);
var doc2 = Document.Create(...);
var doc3 = Document.Create(...);

Document
  .Merge(doc1, doc2, doc3)
  .WithMetadata(...)
  .GeneratePdf(...)
```

Furthermore you can specifiy how page numbers should be handled for a merged document. There are two modes:

**Seperate (Default)**:  Each document is treated as a 'single' one in terms of page numbering.
**Continuous**: All documents should be treated as a 'single' document in terms of page numbering.

E.g: Merged document that contains three documents, with a page count of 2, 3, 1
| Position | Seperate | Continuous | 
| --- | --- | --- |
| Doc 1 Page 1 | 1/2 | 1/6 |
| Doc 1 Page 2 | 2/2 | 2/6 |
| Doc 2 Page 1 | 1/3 | 3/6 |
| Doc 2 Page 2 | 2/3 | 4/6 |
| Doc 2 Page 3 | 3/3 | 5/6 |
| Doc 3 Page 1 | 1/1 | 6/6 |

Code sample:
```csharp
Document
  .Merge(...)
  .SeperatePageNumbers() //or .ContinuousPageNumbers()
  .WithMetadata(...)
  .GeneratePdf(...)
```

See discussion #365 for futher info and motivation of this feature.