### PR TITLE
Moving cell visibility optimizations

### DIFF
--- a/QuestPDF/Elements/Table/Table.cs
+++ b/QuestPDF/Elements/Table/Table.cs
@@ -200,10 +200,6 @@ namespace QuestPDF.Elements.Table
                         currentRow = cell.Row;
                     }
 
-                    // cell visibility optimizations
-                    if (cell.Row > maxRenderingRow)
-                        break;
-
                     // calculate cell position / size
                     var topOffset = rowBottomOffsets[cell.Row - 1];
                     
@@ -225,6 +221,10 @@ namespace QuestPDF.Elements.Table
                         maxRenderingRow = Math.Min(maxRenderingRow, cell.Row - 1);
                         continue;
                     }
+                    
+                    // cell visibility optimizations
+                    if (cell.Row > maxRenderingRow)
+                        break;
                     
                     // update position of the last row that cell occupies
                     var bottomRow = cell.Row + cell.RowSpan - 1;


### PR DESCRIPTION
This is an attempt to fix #320 

Moving the check for cell visibility below the edge cases seems to fix the rendering of cells that wrap over page breaks.
Completely removing the check causes the missing cell to be rendered, but with a border that extends further down than the rest of the row.

I don't fully understand the code, so I'm not sure if this breaks other things. I hope it at least helps.