### PR TITLE
Add PageNumber by Section methods in PageContext and Dynamic

### DIFF
--- a/Source/QuestPDF/Elements/Dynamic.cs
+++ b/Source/QuestPDF/Elements/Dynamic.cs
@@ -25,7 +25,27 @@ namespace QuestPDF.Elements
         {
             Child.SetState(InitialComponentState);
         }
-        
+
+        public int? BeginPageNumberOfSection(string locationName)
+        {
+            return PageContext.GetLocation(locationName)?.PageStart;
+        }
+
+        public int? EndPageNumberOfSection(string locationName)
+        {
+            return PageContext.GetLocation(locationName)?.PageEnd;
+        }
+
+        public int? PageNumberWithinSection(string locationName)
+        {
+            return PageContext.CurrentPage + 1 - PageContext.GetLocation(locationName)?.PageStart;
+        }
+
+        public int? TotalPagesWithinSection(string locationName)
+        {
+            return PageContext.GetLocation(locationName)?.Length;
+        }
+
         internal override SpacePlan Measure(Size availableSpace)
         {
             var result = GetContent(availableSpace, acceptNewState: false);

--- a/Source/QuestPDF/Elements/Dynamic.cs
+++ b/Source/QuestPDF/Elements/Dynamic.cs
@@ -26,26 +26,6 @@ namespace QuestPDF.Elements
             Child.SetState(InitialComponentState);
         }
 
-        public int? BeginPageNumberOfSection(string locationName)
-        {
-            return PageContext.GetLocation(locationName)?.PageStart;
-        }
-
-        public int? EndPageNumberOfSection(string locationName)
-        {
-            return PageContext.GetLocation(locationName)?.PageEnd;
-        }
-
-        public int? PageNumberWithinSection(string locationName)
-        {
-            return PageContext.CurrentPage + 1 - PageContext.GetLocation(locationName)?.PageStart;
-        }
-
-        public int? TotalPagesWithinSection(string locationName)
-        {
-            return PageContext.GetLocation(locationName)?.Length;
-        }
-
         internal override SpacePlan Measure(Size availableSpace)
         {
             var result = GetContent(availableSpace, acceptNewState: false);
@@ -118,6 +98,26 @@ namespace QuestPDF.Elements
             container.Size = container.Measure(Size.Max);
             
             return container;
+        }
+
+        public int? BeginPageNumberOfSection(string locationName)
+        {
+            return PageContext.GetLocation(locationName)?.PageStart;
+        }
+
+        public int? EndPageNumberOfSection(string locationName)
+        {
+            return PageContext.GetLocation(locationName)?.PageEnd;
+        }
+
+        public int? PageNumberWithinSection(string locationName)
+        {
+            return PageContext.CurrentPage + 1 - PageContext.GetLocation(locationName)?.PageStart;
+        }
+
+        public int? TotalPagesWithinSection(string locationName)
+        {
+            return PageContext.GetLocation(locationName)?.Length;
         }
     }
 

--- a/Source/QuestPDF/Infrastructure/IPageContext.cs
+++ b/Source/QuestPDF/Infrastructure/IPageContext.cs
@@ -9,11 +9,15 @@ namespace QuestPDF.Infrastructure
         public int PageEnd { get; set; }
         public int Length => PageEnd - PageStart + 1;
     }
-    
+
     internal interface IPageContext
     {
         int CurrentPage { get; }
         void SetSectionPage(string name);
         DocumentLocation? GetLocation(string name);
+        int? BeginPageNumberOfSection(string locationName);
+        int? EndPageNumberOfSection(string locationName);
+        int? PageNumberWithinSection(string locationName);
+        int? TotalPagesWithinSection(string locationName);
     }
 }

--- a/Source/QuestPDF/Infrastructure/PageContext.cs
+++ b/Source/QuestPDF/Infrastructure/PageContext.cs
@@ -7,7 +7,7 @@ namespace QuestPDF.Infrastructure
     internal class PageContext : IPageContext
     {
         public const string DocumentLocation = "document";
-        
+
         private List<DocumentLocation> Locations { get; } = new();
         public int CurrentPage { get; private set; }
 
@@ -16,7 +16,7 @@ namespace QuestPDF.Infrastructure
             CurrentPage = number;
             SetSectionPage(DocumentLocation);
         }
-        
+
         public void SetSectionPage(string name)
         {
             var location = GetLocation(name);
@@ -29,7 +29,7 @@ namespace QuestPDF.Infrastructure
                     PageStart = CurrentPage,
                     PageEnd = CurrentPage
                 };
-                
+
                 Locations.Add(location);
             }
 
@@ -40,6 +40,26 @@ namespace QuestPDF.Infrastructure
         public DocumentLocation? GetLocation(string name)
         {
             return Locations.FirstOrDefault(x => x.Name == name);
+        }
+
+        public int? BeginPageNumberOfSection(string locationName)
+        {
+            return GetLocation(locationName)?.PageStart;
+        }
+
+        public int? EndPageNumberOfSection(string locationName)
+        {
+            return GetLocation(locationName)?.PageEnd;
+        }
+
+        public int? PageNumberWithinSection(string locationName)
+        {
+            return CurrentPage + 1 - GetLocation(locationName)?.PageStart;
+        }
+
+        public int? TotalPagesWithinSection(string locationName)
+        {
+            return GetLocation(locationName)?.Length;
         }
     }
 }


### PR DESCRIPTION
I needed to do checks based on page number in the section context writing Dynamic components.

In particular i need to check, in a Dynamic component placed in the body of the page, if the current page is the first or the last one of current section.

To avoid duplication of logic I created PageNumber by section methods in PageContext and then called them from TextExtensions (already existing methods) and in Dynamic (new methods).

This PR satisfies #469 discussion.