### PR TITLE
fix glyph check in FontFallback.MatchFallbackOption

### DIFF
--- a/Source/QuestPDF/Elements/Text/FontFallback.cs
+++ b/Source/QuestPDF/Elements/Text/FontFallback.cs
@@ -86,7 +86,12 @@ namespace QuestPDF.Elements.Text
                         return fallbackOption;
                 }
 
-                throw CreateNotMatchingFontException(codepoint);
+                if (Settings.CheckIfAllTextGlyphsAreAvailable)
+                {
+                    throw CreateNotMatchingFontException(codepoint);
+                }
+
+                return fallbackOptions.First();
             }
 
             static Exception CreateNotMatchingFontException(int codepoint)


### PR DESCRIPTION
The fix for https://github.com/QuestPDF/QuestPDF/issues/504