### PR TITLE
`private` methods that don't access any instance members were made `static`

### DIFF
--- a/Source/QuestPDF.Examples/ContentDirectionExamples.cs
+++ b/Source/QuestPDF.Examples/ContentDirectionExamples.cs
@@ -12,7 +12,7 @@ namespace QuestPDF.Examples
 {
     public class ContentDirectionExamples
     {
-        private Action<IContainer> ContentDirectionTemplate(Action<IContainer> content)
+        private static Action<IContainer> ContentDirectionTemplate(Action<IContainer> content)
         {
             return container =>
             {

--- a/Source/QuestPDF.Examples/DynamicOptimizedExample.cs
+++ b/Source/QuestPDF.Examples/DynamicOptimizedExample.cs
@@ -74,7 +74,7 @@ namespace QuestPDF.Examples
             };
         }
 
-        private IDynamicElement ComposeHeader(DynamicContext context)
+        private static IDynamicElement ComposeHeader(DynamicContext context)
         {
             return context.CreateElement(element =>
             {
@@ -95,7 +95,7 @@ namespace QuestPDF.Examples
             });
         }
         
-        private IDynamicElement ComposeFooter(DynamicContext context, IEnumerable<OrderItem> items)
+        private static IDynamicElement ComposeFooter(DynamicContext context, IEnumerable<OrderItem> items)
         {
             var total = items.Sum(x => x.Count * x.Price);
 

--- a/Source/QuestPDF.Previewer/InteractiveCanvas.cs
+++ b/Source/QuestPDF.Previewer/InteractiveCanvas.cs
@@ -170,7 +170,7 @@ class InteractiveCanvas : ICustomDrawOperation
             SKImageFilter.CreateDropShadowOnly(0, 10, 14, 14, SKColors.Black.WithAlpha(32)))
     };
     
-    private void DrawBlankPage(SKCanvas canvas, float width, float height)
+    private static void DrawBlankPage(SKCanvas canvas, float width, float height)
     {
         canvas.DrawRect(0, 0, width, height, BlankPageShadowPaint);
         canvas.DrawRect(0, 0, width, height, BlankPagePaint);

--- a/Source/QuestPDF.Previewer/PreviewerWindowViewModel.cs
+++ b/Source/QuestPDF.Previewer/PreviewerWindowViewModel.cs
@@ -68,7 +68,7 @@ namespace QuestPDF.Previewer
             OpenLink(filePath);
         }
         
-        private void OpenLink(string path)
+        private static void OpenLink(string path)
         {
             using var openBrowserProcess = new Process
             {

--- a/Source/QuestPDF.ReportSample/Layouts/SectionTemplate.cs
+++ b/Source/QuestPDF.ReportSample/Layouts/SectionTemplate.cs
@@ -48,8 +48,8 @@ namespace QuestPDF.ReportSample.Layouts
                     });
                 });
         }
-        
-        void MapElement(IContainer container, ReportSectionMap model)
+
+        static void MapElement(IContainer container, ReportSectionMap model)
         {
             if (model.Location == null)
             {
@@ -65,8 +65,8 @@ namespace QuestPDF.ReportSample.Layouts
                 column.Item().Text(model.Location.Format());
             });
         }
-        
-        void PhotosElement(IContainer container, ReportSectionPhotos model)
+
+        static void PhotosElement(IContainer container, ReportSectionPhotos model)
         {
             if (model.PhotoCount == 0)
             {

--- a/Source/QuestPDF.ReportSample/Layouts/TableOfContentsTemplate.cs
+++ b/Source/QuestPDF.ReportSample/Layouts/TableOfContentsTemplate.cs
@@ -39,7 +39,7 @@ namespace QuestPDF.ReportSample.Layouts
                 });
         }
 
-        private void DrawLink(IContainer container, int number, string locationName)
+        private static void DrawLink(IContainer container, int number, string locationName)
         {
             container
                 .SectionLink(locationName)

--- a/Source/QuestPDF.UnitTests/DynamicImageTests.cs
+++ b/Source/QuestPDF.UnitTests/DynamicImageTests.cs
@@ -83,8 +83,8 @@ namespace QuestPDF.UnitTests
             var image = GenerateImage(size.Width, size.Height);
             return image.Encode(SKEncodedImageFormat.Png, 100).ToArray();
         }
-        
-        SKImage GenerateImage(int width, int height)
+
+        static SKImage GenerateImage(int width, int height)
         {
             var imageInfo = new SKImageInfo(width, height);
             using var surface = SKSurface.Create(imageInfo);

--- a/Source/QuestPDF.UnitTests/FontStyleSetTests.cs
+++ b/Source/QuestPDF.UnitTests/FontStyleSetTests.cs
@@ -9,7 +9,7 @@ namespace QuestPDF.UnitTests
     [TestFixture]
     public class FontStyleSetTests
     {
-        private void ExpectComparisonOrder(SKFontStyle target, SKFontStyle[] styles)
+        private static void ExpectComparisonOrder(SKFontStyle target, SKFontStyle[] styles)
         {
             for (var i = 0; i < styles.Length - 1; i++)
             {

--- a/Source/QuestPDF.UnitTests/ImageTests.cs
+++ b/Source/QuestPDF.UnitTests/ImageTests.cs
@@ -160,7 +160,7 @@ namespace QuestPDF.UnitTests
                 .Length;
         }
 
-        DocumentImage GenerateDocumentImage(int width, int height)
+        static DocumentImage GenerateDocumentImage(int width, int height)
         {
             var image = Placeholders.Image(width, height);
             return DocumentImage.FromBinaryData(image);

--- a/Source/QuestPDF/Drawing/Proxy/CacheProxy.cs
+++ b/Source/QuestPDF/Drawing/Proxy/CacheProxy.cs
@@ -37,7 +37,7 @@ namespace QuestPDF.Drawing.Proxy
             base.Draw(availableSpace);
         }
 
-        private bool IsClose(float x, float y)
+        private static bool IsClose(float x, float y)
         {
             return Math.Abs(x - y) < Size.Epsilon;
         }

--- a/Source/QuestPDF/Elements/Inlined.cs
+++ b/Source/QuestPDF/Elements/Inlined.cs
@@ -184,8 +184,8 @@ namespace QuestPDF.Elements
                 ? InlinedAlignment.Left
                 : InlinedAlignment.Right;
         }
-        
-        Size GetLineSize(ICollection<InlinedMeasurement> measurements)
+
+        static Size GetLineSize(ICollection<InlinedMeasurement> measurements)
         {
             var width = measurements.Sum(x => x.Size.Width);
             var height = measurements.Max(x => x.Size.Height);

--- a/Source/QuestPDF/Elements/Table/Table.cs
+++ b/Source/QuestPDF/Elements/Table/Table.cs
@@ -134,7 +134,7 @@ namespace QuestPDF.Elements.Table
                 ResetState();
         }
 
-        private int FindLastRenderedRow(ICollection<TableCellRenderingCommand> commands)
+        private static int FindLastRenderedRow(ICollection<TableCellRenderingCommand> commands)
         {
             return commands
                 .GroupBy(x => x.Cell.Row)

--- a/Source/QuestPDF/Previewer/PreviewerService.cs
+++ b/Source/QuestPDF/Previewer/PreviewerService.cs
@@ -95,7 +95,7 @@ namespace QuestPDF.Previewer
             }
         }
 
-        private void CheckVersionCompatibility(Version version)
+        private static void CheckVersionCompatibility(Version version)
         {
             if (version.Major == RequiredPreviewerVersionMajor && version.Minor == RequiredPreviewerVersionMinor)
                 return;


### PR DESCRIPTION
These methods aren't part of any public API, and the `static` keyword gives us certain guarantees