### PR TITLE
Fixed license configuration links in ValidateLicense exception message

### DIFF
--- a/Source/QuestPDF/Drawing/DocumentGenerator.cs
+++ b/Source/QuestPDF/Drawing/DocumentGenerator.cs
@@ -76,7 +76,7 @@ namespace QuestPDF.Drawing
                 $"The library does not require any license key. We trust our users, and therefore the process is simple. " +
                 $"To disable license validation and turn off this exception, please configure an eligible license using the QuestPDF.Settings.License API, for example: {newParagraph}" +
                 $"\"QuestPDF.Settings.License = LicenseType.Community;\" {newParagraph}" +
-                $"Learn more on: https://www.questpdf.com/license-configuration.html {newParagraph}";
+                $"Learn more on: https://www.questpdf.com/license/configuration.html {newParagraph}";
             
             throw new Exception(exceptionMessage)
             {


### PR DESCRIPTION
Fixed the link error to the License configuration documentation.