### PR TITLE
(#457) Fix empty string creation if the fallback font is applied from the beginning of the text

### DIFF
--- a/Source/QuestPDF/Elements/Text/FontFallback.cs
+++ b/Source/QuestPDF/Elements/Text/FontFallback.cs
@@ -42,11 +42,16 @@ namespace QuestPDF.Elements.Text
                 if (newFallbackOption == spanFallbackOption)
                     continue;
 
-                yield return new TextRun
+                var fallbackGlyphCount = i - spanStartIndex;
+
+                if (spanStartIndex != fallbackGlyphCount)
                 {
-                    Content = text.Substring(spanStartIndex, i - spanStartIndex),
-                    Style = spanFallbackOption.Style
-                };
+                    yield return new TextRun
+                    {
+                        Content = text.Substring(spanStartIndex, fallbackGlyphCount),
+                        Style = spanFallbackOption.Style
+                    };
+                }
 
                 spanStartIndex = i;
                 spanFallbackOption = newFallbackOption;


### PR DESCRIPTION
Closes #457 

**Problem description:**
If your text starts with characters from a fallback font, a phantom empty string is generated by the `SplitWithFontFallback()` method:
```c#
yield return new TextRun
{
    Content = text.Substring(spanStartIndex, i - spanStartIndex),
    Style = spanFallbackOption.Style
};
``` 
`text.Substring(spanStartIndex, i - spanStartIndex)` returns `string.Empty` when `i = 0` and `spanStartIndex = 0`

This change also fixes a layout error in the `Previewer`. An empty line was breaking the calculation of text hyphenation.

![solved](https://github.com/QuestPDF/QuestPDF/assets/55300023/b9a7e8bd-1956-4993-b5d9-9e22ee5a294b)