### PR TITLE
Fix: Update logic to find native files (icudtl.dat & QuestPdfSkia.dll)

### DIFF
--- a/Source/QuestPDF/Skia/SkNativeDependencyProvider.cs
+++ b/Source/QuestPDF/Skia/SkNativeDependencyProvider.cs
@@ -7,18 +7,23 @@ namespace QuestPDF.Skia;
 
 internal static class SkNativeDependencyProvider
 {
-    private static string _baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-
     public static void EnsureNativeFileAvailability()
     {
-        var nativeFiles = Directory.GetFiles(GetNativeFileSourcePath());
+        var nativeFilesPath = GetNativeFileSourcePath();
+        
+        if (nativeFilesPath == null)
+            return;
 
-        foreach (var nativeFileSourcePath in nativeFiles)
+        foreach (var nativeFilePath in Directory.GetFiles(nativeFilesPath))
         {
-            var nativeFileName = Path.GetFileName(nativeFileSourcePath);
-            var runtimePath = GetNativeFileRuntimePath(nativeFileName);
-
-            CopyFileIfNewer(nativeFileSourcePath, runtimePath);
+            var targetPath = new FileInfo(nativeFilePath)
+                .Directory
+                .Parent // native
+                .Parent // platform
+                .Parent // runtimes
+                .FullName;
+            
+            CopyFileIfNewer(nativeFilePath, targetPath);
         }
     }
     
@@ -35,24 +40,29 @@ internal static class SkNativeDependencyProvider
         }
     }
     
-    static string GetNativeFileSourcePath()
+    static string? GetNativeFileSourcePath()
     {
         var platform = GetRuntimePlatform();
-        var nativeFileSourcePath = Path.Combine(_baseDirectory, "runtimes", platform, "native");
 
-        if (Directory.Exists(nativeFileSourcePath))
-            return nativeFileSourcePath;
+        var availableLocations = new[]
+        {
+            AppDomain.CurrentDomain.RelativeSearchPath, 
+            AppDomain.CurrentDomain.BaseDirectory,
+            new FileInfo(typeof(SkNativeDependencyProvider).Assembly.Location).Directory?.FullName
+        };
+        
+        foreach (var location in availableLocations)
+        {
+            if (string.IsNullOrEmpty(location))
+                continue;
 
-        var applicationDirectory = AppDomain.CurrentDomain.RelativeSearchPath;
+            var nativeFileSourcePath = Path.Combine(location, "runtimes", platform, "native");
 
-        if (!string.IsNullOrEmpty(applicationDirectory))
-            nativeFileSourcePath = Path.Combine(applicationDirectory, "runtimes", platform, "native");
+            if (Directory.Exists(nativeFileSourcePath))
+                return nativeFileSourcePath;
+        }
 
-        if (!Directory.Exists(nativeFileSourcePath))
-            throw new DirectoryNotFoundException($"Native files not found in {nativeFileSourcePath}");
-
-        _baseDirectory = applicationDirectory!;
-        return nativeFileSourcePath;
+        return null;
     }
         
     static string GetRuntimePlatform()
@@ -76,11 +86,6 @@ internal static class SkNativeDependencyProvider
         }
 
         throw new InitializationException("Your runtime is currently not supported by QuestPDF.");
-    }
-        
-    static string GetNativeFileRuntimePath(string fileName)
-    {
-        return Path.Combine(_baseDirectory, fileName);
     }
 
     static void CopyFileIfNewer(string sourcePath, string targetPath)


### PR DESCRIPTION
Added a fix for finding native files (icudtl.dat & QuestPdfSkia.dll)
In a .net 4.8 application, the baseDirectory is not the bin folder.

In response to https://github.com/QuestPDF/QuestPDF/discussions/622#discussioncomment-8695313 
