### PR TITLE
Implemented color validation logic in place

### DIFF
--- a/Source/QuestPDF/Helpers/ColorValidator.cs
+++ b/Source/QuestPDF/Helpers/ColorValidator.cs
@@ -26,15 +26,52 @@ namespace QuestPDF.Helpers
 
             static bool IsColorValid(string color)
             {
-                try
-                {
-                    SKColor.Parse(color);
-                    return true;
-                }
-                catch
+                if (string.IsNullOrWhiteSpace(color))
                 {
                     return false;
                 }
+
+                // clean up string
+                color = color.Trim();
+                var startIndex = color[0] == '#' ? 1 : 0;
+
+                var len = color.Length - startIndex;
+                if (len == 3 || len == 4)
+                {
+                    // parse [A]
+                    if (len == 4 && !byte.TryParse(string.Concat(new string(color[startIndex], 2)),
+                            NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _))
+                    {
+                        return false;
+                    }
+
+                    // parse RGB
+                    if (!byte.TryParse(new string(color[len - 3 + startIndex], 2), NumberStyles.HexNumber,
+                            CultureInfo.InvariantCulture, out _) ||
+                        !byte.TryParse(new string(color[len - 2 + startIndex], 2), NumberStyles.HexNumber,
+                            CultureInfo.InvariantCulture, out _) ||
+                        !byte.TryParse(new string(color[len - 1 + startIndex], 2), NumberStyles.HexNumber,
+                            CultureInfo.InvariantCulture, out _))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                if (len == 6 || len == 8)
+                {
+                    // parse [AA]RRGGBB
+                    if (!uint.TryParse(color.Substring(startIndex), NumberStyles.HexNumber,
+                            CultureInfo.InvariantCulture, out _))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                return false;
             }
         }
     }


### PR DESCRIPTION
Calling SkiaSharp.Parse adds a tiny bit of overheads and memory allocation that can be avoided by doing the color code syntax validation in-place.