### PR TITLE
Change LatoFont as optional external dependency

### DIFF
--- a/Source/QuestPDF/Build/QuestPDF.targets
+++ b/Source/QuestPDF/Build/QuestPDF.targets
@@ -1,10 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup>
-        <None Include="$(MSBuildThisFileDirectory)\..\LatoFont\*.*">
-            <Visible>false</Visible>
-            <Link>LatoFont\%(RecursiveDir)%(Filename)%(Extension)</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
 </Project>

--- a/Source/QuestPDF/Drawing/FontManager.cs
+++ b/Source/QuestPDF/Drawing/FontManager.cs
@@ -87,6 +87,21 @@ namespace QuestPDF.Drawing
                     
                 }
             }
+
+            // Register Lato font if available
+            var latoFontPath = Path.Combine(Helpers.Helpers.ApplicationFilesPath, "LatoFont", "Lato-Regular.ttf");
+            if (File.Exists(latoFontPath))
+            {
+                try
+                {
+                    using var latoFontStream = File.OpenRead(latoFontPath);
+                    RegisterFont(latoFontStream);
+                }
+                catch
+                {
+                    // Ignore any exceptions while registering Lato font
+                }
+            }
         }
     }
 }

--- a/Source/QuestPDF/Helpers/Fonts.cs
+++ b/Source/QuestPDF/Helpers/Fonts.cs
@@ -18,7 +18,6 @@ namespace QuestPDF.Helpers
         public const string CourierNew = "Courier New";
         public const string Georgia = "Georgia";
         public const string Impact = "Impact";
-        public const string Lato = "Lato";
         public const string LucidaConsole = "Lucida Console";
         public const string SegoeSD = "Segoe SD";
         public const string SegoeUI = "Segoe UI";

--- a/Source/QuestPDF/QuestPDF.csproj
+++ b/Source/QuestPDF/QuestPDF.csproj
@@ -40,13 +40,6 @@
             <PackagePath>%(RecursiveDir)\%(Filename)%(Extension)</PackagePath>
         </None>
         
-        <None Include="LatoFont\*.*">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-            <Pack>true</Pack>
-            <PackagePath>LatoFont</PackagePath>
-        </None>
-        
         <None Include="Runtimes\**\*.*">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>


### PR DESCRIPTION
Related to #913

Make the Lato font an optional external dependency.

* **Hide Lato font from IDE solution structure tree**
  - Remove the `<None>` item group that includes the Lato font in `Source/QuestPDF/Build/QuestPDF.targets`.
* **Exclude Lato font from application build artifact**
  - Remove the `<None>` item group that includes the Lato font in `Source/QuestPDF/QuestPDF.csproj`.
* **Make Lato font registration optional**
  - Modify the `RegisterLibraryDefaultFonts` method in `Source/QuestPDF/Drawing/FontManager.cs` to register the Lato font only if it is available.
* **Remove Lato font constant**
  - Remove the `Lato` constant from `Source/QuestPDF/Helpers/Fonts.cs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/QuestPDF/QuestPDF/issues/913?shareId=9d299cde-0484-407b-816a-406bfc8b8b97).