### PR TITLE
Add AutoFontSize feature to TextBlock for automatic font size adjustment

### DIFF
--- a/Source/QuestPDF/Elements/Text/TextBlock.cs
+++ b/Source/QuestPDF/Elements/Text/TextBlock.cs
@@ -29,6 +29,7 @@ namespace QuestPDF.Elements.Text
         
         public TextStyle DefaultTextStyle { get; set; } = TextStyle.Default;
         public float[]? AutoFontSizeCandidates { get; set; }
+        public int? AutoFontMaxLines { get; set; }
 
         // cache
         private bool RebuildParagraphForEveryPage { get; set; }
@@ -276,7 +277,9 @@ namespace QuestPDF.Elements.Text
                 CalculateParagraphMetrics(availableSpace);
                 
                 var totalHeight = LineMetrics.Sum(x => x.Height);
-                var fits = MaximumWidth <= availableSpace.Width && totalHeight <= availableSpace.Height;
+                var fits = MaximumWidth <= availableSpace.Width 
+                    && totalHeight <= availableSpace.Height 
+                    && (AutoFontMaxLines == null || LineMetrics.Length <= AutoFontMaxLines);
                 if (fits)
                 {
                     bestIdx = midIdx;

--- a/Source/QuestPDF/Fluent/TextExtensions.cs
+++ b/Source/QuestPDF/Fluent/TextExtensions.cs
@@ -68,6 +68,58 @@ namespace QuestPDF.Fluent
             TextBlock = textBlock;
         }
 
+        /// <summary>
+        /// Automatically try to find the best font size that fits the width and height of the container.
+        /// </summary>
+        /// <param name="minSize">The lower bound of the font size range (inclusive).</param>
+        /// <param name="maxSize">The upper bound of the font size range (inclusive).</param>
+        /// <param name="stepSize">The step between font sizes.</param>
+        /// <param name="maxLines">The maximum number of lines the text can span. If null, the text can span multiple lines.</param>
+        public TextBlockDescriptor AutoFontSize(float minSize, float maxSize, float stepSize, int? maxLines = null)
+        {
+            if (minSize < 0)
+                throw new ArgumentException("Minimum font size must be greater or equal to zero", nameof(minSize));
+            if (maxSize < minSize)
+                throw new ArgumentException("Maximum font size must be greater or equal to the minimum font size", nameof(maxSize));
+            if (stepSize <= 0) 
+                throw new ArgumentException("Step size must be greater than zero", nameof(stepSize));
+
+            int count = (int)((maxSize - minSize) / stepSize) + 1;
+
+            AutoFontSize(
+                Enumerable.Range(0, count)
+                .Select(i => minSize + i * stepSize),
+                maxLines
+            );
+
+            return this;
+        }
+
+        /// <summary>
+        /// Automatically try to find the best font size that fits the width and height of the container.
+        /// </summary>
+        /// <param name="sizes">A strictly increasing array of floats greater than zero that represent the possible font sizes</param>
+        /// <param name="maxLines">The maximum number of lines the text can span. If null, the text can span multiple lines.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public TextBlockDescriptor AutoFontSize(IEnumerable<float> sizes, int? maxLines = null)
+        {
+            if (sizes == null)
+                throw new ArgumentNullException(nameof(sizes));
+            if (!sizes.Any())
+                throw new ArgumentException("The collection of font sizes must not be empty", nameof(sizes));
+            if (sizes.Aggregate((a, b) => {
+                if (a >= b) throw new ArgumentException("All font sizes must be strictly increasing", nameof(sizes));
+                return b;
+            }) <= 0) 
+                throw new ArgumentException("All font sizes must be greater than zero", nameof(sizes));
+
+            TextBlock.AutoFontSizeCandidates = sizes.ToArray();
+            TextBlock.AutoFontMaxLines = maxLines;
+
+            return this;
+        }
+
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="text.alignment.left"]/*' />
         public TextBlockDescriptor AlignLeft()
         {
@@ -170,7 +222,9 @@ namespace QuestPDF.Fluent
         /// <param name="minSize">The lower bound of the font size range (inclusive).</param>
         /// <param name="maxSize">The upper bound of the font size range (inclusive).</param>
         /// <param name="stepSize">The step between font sizes.</param>
-        public void AutoFontSize(float minSize, float maxSize, float stepSize) {
+        /// <param name="maxLines">The maximum number of lines the text can span. If null, the text can span multiple lines.</param>
+        public void AutoFontSize(float minSize, float maxSize, float stepSize, int? maxLines = null) 
+        {
             if (minSize < 0)
                 throw new ArgumentException("Minimum font size must be greater or equal to zero", nameof(minSize));
             if (maxSize < minSize)
@@ -182,7 +236,8 @@ namespace QuestPDF.Fluent
 
             AutoFontSize(
                 Enumerable.Range(0, count)
-                .Select(i => minSize + i * stepSize)
+                .Select(i => minSize + i * stepSize),
+                maxLines
             );
         }
 
@@ -190,9 +245,11 @@ namespace QuestPDF.Fluent
         /// Automatically try to find the best font size that fits the width and height of the container.
         /// </summary>
         /// <param name="sizes">A strictly increasing array of floats greater than zero that represent the possible font sizes</param>
+        /// <param name="maxLines">The maximum number of lines the text can span. If null, the text can span multiple lines.</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public void AutoFontSize(IEnumerable<float> sizes) {
+        public void AutoFontSize(IEnumerable<float> sizes, int? maxLines = null) 
+        {
             if (sizes == null)
                 throw new ArgumentNullException(nameof(sizes));
             if (!sizes.Any())
@@ -204,6 +261,7 @@ namespace QuestPDF.Fluent
                 throw new ArgumentException("All font sizes must be greater than zero", nameof(sizes));
 
             TextBlock.AutoFontSizeCandidates = sizes.ToArray();
+            TextBlock.AutoFontMaxLines = maxLines;
         }
   
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="text.alignment.left"]/*' />

--- a/Source/QuestPDF/Fluent/TextExtensions.cs
+++ b/Source/QuestPDF/Fluent/TextExtensions.cs
@@ -163,6 +163,48 @@ namespace QuestPDF.Fluent
         {
             DefaultStyle = style(TextStyle.Default);
         }
+
+        /// <summary>
+        /// Automatically try to find the best font size that fits the width and height of the container.
+        /// </summary>
+        /// <param name="minSize">The lower bound of the font size range (inclusive).</param>
+        /// <param name="maxSize">The upper bound of the font size range (inclusive).</param>
+        /// <param name="stepSize">The step between font sizes.</param>
+        public void AutoFontSize(float minSize, float maxSize, float stepSize) {
+            if (minSize < 0)
+                throw new ArgumentException("Minimum font size must be greater or equal to zero", nameof(minSize));
+            if (maxSize < minSize)
+                throw new ArgumentException("Maximum font size must be greater or equal to the minimum font size", nameof(maxSize));
+            if (stepSize <= 0) 
+                throw new ArgumentException("Step size must be greater than zero", nameof(stepSize));
+
+            int count = (int)((maxSize - minSize) / stepSize) + 1;
+
+            AutoFontSize(
+                Enumerable.Range(0, count)
+                .Select(i => minSize + i * stepSize)
+            );
+        }
+
+        /// <summary>
+        /// Automatically try to find the best font size that fits the width and height of the container.
+        /// </summary>
+        /// <param name="sizes">A strictly increasing array of floats greater than zero that represent the possible font sizes</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public void AutoFontSize(IEnumerable<float> sizes) {
+            if (sizes == null)
+                throw new ArgumentNullException(nameof(sizes));
+            if (!sizes.Any())
+                throw new ArgumentException("The collection of font sizes must not be empty", nameof(sizes));
+            if (sizes.Aggregate((a, b) => {
+                if (a >= b) throw new ArgumentException("All font sizes must be strictly increasing", nameof(sizes));
+                return b;
+            }) <= 0) 
+                throw new ArgumentException("All font sizes must be greater than zero", nameof(sizes));
+
+            TextBlock.AutoFontSizeCandidates = sizes.ToArray();
+        }
   
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="text.alignment.left"]/*' />
         public void AlignLeft()

--- a/Source/QuestPDF/Infrastructure/TextStyle.cs
+++ b/Source/QuestPDF/Infrastructure/TextStyle.cs
@@ -71,6 +71,11 @@ namespace QuestPDF.Infrastructure
 
         private SkTextStyle? SkTextStyleCache;
         
+        internal void ClearCache() 
+        {
+            SkTextStyleCache = null;
+        }
+
         internal SkTextStyle GetSkTextStyle()
         {
             if (SkTextStyleCache != null)


### PR DESCRIPTION
Hello QuestPDF team,

First of all, thank you for developing such an amazing library! We've been using QuestPDF in our projects, and it has been great for our document generation needs.

We have a use case where we need text to dynamically adjust its font size to fit within a given container. Additionally, we require control over the maximum number of lines the text can span and the exact font sizes that can be used. Because of this we implemented some changes that we would like to share with this PR.

**Why Not `ScaleToFit`?**

Initially, we tried using the `ScaleToFit` feature, but we encountered some limitations:

- **No Control Over Maximum Lines**: `ScaleToFit` doesn't allow us to specify the maximum number of lines the text can occupy, which is required for our use case.
- **Issues with Smaller Containers**: In smaller containers, `ScaleToFit` sometimes doesn't work as expected, leading to text overflow or inadequate scaling (see example below).

To overcome these challenges, we've implemented an `AutoFontSize` feature for the `TextBlock` element.

**Feature Highlights:**

- **Automatic Font Size Adjustment**: The text block automatically selects the largest font size from a provided range that allows the text to fit within the available space.
- **Maximum Line Control**: You can specify the maximum number of lines the text is allowed to span, ensuring consistent layout.

**Usage Examples:**

We've added two extension methods to the `TextBlockDescriptor` and `ITextDescriptor` interfaces:

1. **Using a Font Size Range:**

   ```csharp
   textBlock.AutoFontSize(minSize: 8, maxSize: 20, stepSize: 0.5f, maxLines: 2);
   ```

2. **Using Specific Font Sizes:**

   ```csharp
   textBlock.AutoFontSize([8f, 10f, 12f, 14f], maxLines: 1);
   ```

**Examples:**

In the attached example, we compare the `ScaleToFit` and `AutoFontSize` features under various container sizes and font families. You'll notice that `AutoFontSize` provides better control over the text layout, especially in small containers and when limiting the number of lines.

[example.pdf](https://github.com/user-attachments/files/16991320/example.pdf)

<details><summary>Code Details</summary>
<p>

```csharp
using CheckNet.Labelizer.Engine.Extensions;
using QuestPDF.Fluent;
using QuestPDF.Helpers;
using QuestPDF.Infrastructure;
using QuestPDF.Previewer;

List<(float, float)> sizes = [
    (50, 40),
    (40, 50),
    (100, 20),
    (20, 100),
    (60, 60)
];
List<string> fonts = [
    "Arial", // Sans-Serif
    "Times New Roman", // Serif
    "Consolas", // Monospace
    "Impact" // Fancy
];

void ComposeScaleToFitExample(IContainer container, string text, string fontName, float width, float height)
{
    container.Column(col =>
    {
        col.Item()
            .Width(width)
            .Height(height)
            .DebugArea()
            .VerticalAlign(VerticalAlignment.Bottom)
            .Row(row =>
                row.AutoItem()
                    .Width(width)
                    .ScaleToFit()
                    .DebugArea(color: Colors.Blue.Lighten1)
                    .Text(text)
                    .FontFamily(fontName)
                    .LineHeight(.8f)
                    .FontSize(Math.Max(width, height))
                    .ExtraBold()
            );
    });
}

void ComposeAutoFontSizeExample(IContainer container, string text, string fontName, float width, float height, int? maxLines = 1)
{
    container.Column(col =>
    {
        col.Item()
            .Width(width)
            .Height(height)
            .DebugArea()
            .VerticalAlign(VerticalAlignment.Bottom)
            .Row(row =>
                row.AutoItem()
                    .MaxWidth(width)
                    .MaxHeight(height)
                    .DebugArea(color: Colors.Blue.Lighten1)
                    .Text(text)
                    .FontFamily(fontName)
                    .LineHeight(.8f)
                    .AutoFontSize(.5f, Math.Max(width, height), .5f, maxLines)
                    .ExtraBold()
            );
    });
}

var doc = Document.Create(doc =>
{
    doc.Page(page =>
    {
        page.Margin(20);
        page.MinSize(new PageSize(1, 1));
        page.MaxSize(new PageSize(Size.Max.Width, Size.Max.Height));
        page.Content()
            .Column(col =>
            {
                col.Item().Row(row =>
                {
                    row.Spacing(5);
                    foreach (var font in fonts)
                    {
                        row.AutoItem().Column(col =>
                        {
                            col.Spacing(5);
                            col.Item().Text($"Font: {font}").FontSize(16).FontColor(Colors.Black);
                            foreach (var (width, height) in sizes)
                            {
                                col.Item().Text($"Red rectangle: width={width}, height={height}").FontSize(12).FontColor(Colors.Grey.Darken1);
                                col.Item()
                                    .BorderBottom(.5f)
                                    .Row(row =>
                                    {
                                        row.Spacing(5);

                                        row.ConstantItem(100)
                                            .Text("ScaleToFit")
                                            .FontColor(Colors.Grey.Lighten1)
                                            .FontSize(10);
                                        ComposeScaleToFitExample(row.AutoItem(), "One Size", font, width, height);
                                        ComposeScaleToFitExample(row.AutoItem(), "XXXL", font, width, height);
                                        ComposeScaleToFitExample(row.AutoItem(), "XL", font, width, height);
                                        ComposeScaleToFitExample(row.AutoItem(), "S", font, width, height);
                                    });

                                col.Item()
                                    .BorderBottom(.5f)
                                    .Row(row =>
                                    {
                                        row.Spacing(5);

                                        row.ConstantItem(100)
                                            .Text("AutoFontSize")
                                            .FontColor(Colors.Grey.Lighten1)
                                            .FontSize(10);
                                        ComposeAutoFontSizeExample(row.AutoItem(), "One Size", font, width, height, maxLines: null);
                                        ComposeAutoFontSizeExample(row.AutoItem(), "XXXL", font, width, height, maxLines: null);
                                        ComposeAutoFontSizeExample(row.AutoItem(), "XL", font, width, height, maxLines: null);
                                        ComposeAutoFontSizeExample(row.AutoItem(), "S", font, width, height, maxLines: null);
                                    });

                                col.Item()
                                    .BorderBottom(.5f)
                                    .Row(row =>
                                    {
                                        row.Spacing(5);

                                        row.ConstantItem(100)
                                            .Text("AutoFontSize (ML: 1)")
                                            .FontColor(Colors.Grey.Lighten1)
                                            .FontSize(10);
                                        ComposeAutoFontSizeExample(row.AutoItem(), "One Size", font, width, height, maxLines: 1);
                                        ComposeAutoFontSizeExample(row.AutoItem(), "XXXL", font, width, height, maxLines: 1);
                                        ComposeAutoFontSizeExample(row.AutoItem(), "XL", font, width, height, maxLines: 1);
                                        ComposeAutoFontSizeExample(row.AutoItem(), "S", font, width, height, maxLines: 1);
                                    });

                                col.Item().Height(20);
                            }
                        });
                    }
                });

            });
    });
});


doc.ShowInPreviewer();
```

</p>
</details>

**Challenges**

For our use case, baseline alignment is important. Especially when varying fonts, sometimes the baseline becomes misaligned. We tried using the `BaselineOffset` to adjust for such shifts but did not manage to get a working prototype, since the text seems to be unresponsive to any changes to this offset. Finding a solution for solving the baseline alignment is still future work. A workaround is setting the `LineHeight` to different values per font. Currently, we use `0.8` in the example.

**Conclusion**

If there is a way to achieve our use case with the existing QuestPDF functionality, we would be excited to learn about it. We have explored the latest release but couldn't find a solution that meets all our requirements. We think this feature enhances the flexibility of text rendering in QuestPDF and could benefit other users with similar requirements.

Thank you for considering this pull request. We're happy to make any adjustments if needed. Also, if our use case can be done with existing QuestPDF functionality, that would be even better, but we did not find a way as of the latest release.