### PR TITLE
fix(companion): Companion App could not display merged documents

### DIFF
--- a/Source/QuestPDF.Companion.TestRunner/Program.cs
+++ b/Source/QuestPDF.Companion.TestRunner/Program.cs
@@ -10,8 +10,9 @@ Settings.License = LicenseType.Professional;
 
 //await RunGenericException();
 //await RunLayoutError();
-await RunSimpleDocument();
+//await RunSimpleDocument();
 //await RunReportDocument();
+await RunMergedDocument();
 
 Task RunGenericException()
 {
@@ -111,4 +112,32 @@ Task RunReportDocument()
     var model = DataSource.GetReport();
     var report = new StandardReport(model);
     return report.ShowInCompanionAsync();
+}
+
+Task RunMergedDocument()
+{
+    var document1 = Document
+        .Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Content()
+                    .Text("Page 1!")
+                    .SemiBold().FontSize(36).FontColor(Colors.Blue.Medium);
+            });
+        });
+    var document2 = Document
+        .Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Content()
+                    .Text("Page 2!")
+                    .SemiBold().FontSize(36).FontColor(Colors.Blue.Medium);
+            });
+        });
+
+    var mergedDocument = Document.Merge(document1, document2);
+
+    return mergedDocument.ShowInCompanionAsync();
 }

--- a/Source/QuestPDF/Drawing/DocumentGenerator.cs
+++ b/Source/QuestPDF/Drawing/DocumentGenerator.cs
@@ -141,6 +141,12 @@ namespace QuestPDF.Drawing
                 })
                 .ToList();
 
+            foreach (var documentPart in documentParts)
+            {
+                if (canvas is CompanionCanvas)
+                    documentPart.Content.VisitChildren(x => x.CreateProxy(y => new LayoutProxy(y)));
+            }
+
             if (document.PageNumberStrategy == MergedDocumentPageNumberStrategy.Continuous)
             {
                 var documentPageContext = new PageContext();
@@ -171,6 +177,9 @@ namespace QuestPDF.Drawing
                     RenderPass(pageContext, canvas, documentPart.Content);
                 }
             }
+
+            if (canvas is CompanionCanvas companionCanvas)
+                companionCanvas.Hierarchy = documentParts[0].Content.ExtractHierarchy();
         }
 
         private static Container ConfigureContent(IDocument document, DocumentSettings settings, bool useOriginalImages)


### PR DESCRIPTION
Hierarchy was not set when rendering Merged documents.

This fix is not complete, as only the first document are shown in the hierarchy pane. This only makes the companion app usable with merged documents.

Fixes #1019 