### PR TITLE
Standardize file extension for MIME type detection

### DIFF
--- a/Source/QuestPDF/Fluent/DocumentOperation.cs
+++ b/Source/QuestPDF/Fluent/DocumentOperation.cs
@@ -352,6 +352,7 @@ public class DocumentOperation
         string GetDefaultMimeType()
         {
             var fileExtension = Path.GetExtension(attachment.FilePath);
+            fileExtension = fileExtension.TrimStart('.').ToLowerInvariant();
             return MimeHelper.FileExtensionToMimeConversionTable.TryGetValue(fileExtension, out var value) ? value : "text/plain";
         }
         


### PR DESCRIPTION
Added a line to trim the leading period and convert the file extension to lowercase before looking it up in the MIME type conversion table. This improves the accuracy of MIME type detection for attachments with varying file extension formats.

Fixes #1119 