### PR TITLE
Add non-ASCII handling tests and update QpdfAPI

### DIFF
--- a/Source/QuestPDF.ZUGFeRD/GenerationTest.cs
+++ b/Source/QuestPDF.ZUGFeRD/GenerationTest.cs
@@ -40,4 +40,39 @@ public class Tests
             .ExtendMetadata(File.ReadAllText("resource-zugferd-metadata.xml"))
             .Save("zugferd-invoice.pdf");
     }
+
+    [Test]
+    public void NonAscii_Test()
+    {
+        // TODO: Please make sure that you are eligible to use the Community license.
+        // To learn more about the QuestPDF licensing, please visit:
+        // https://www.questpdf.com/pricing.html
+        QuestPDF.Settings.License = LicenseType.Community;
+
+        Document
+            .Create(document =>
+            {
+                document.Page(page =>
+                {
+                    page.Content().Text("Här har vi konstiga tecken så som å, ä och ö!");
+                });
+            })
+            .WithSettings(new DocumentSettings { PdfA = true }) // PDF/A-3b
+            .GeneratePdf("åäö-filen.pdf");
+
+        DocumentOperation
+            .LoadFile("åäö-filen.pdf")
+            .AddAttachment(new DocumentOperation.DocumentAttachment
+            {
+                Key = "innehåller-icke-ascii",
+                FilePath = "innehåller-icke-ascii.txt",
+                AttachmentName = "innehåller-icke-ascii.txt",
+                MimeType = "text/normal",
+                Description = "Här måste det finnas icke ascii",
+                Relationship = DocumentOperation.DocumentAttachmentRelationship.Source,
+                CreationDate = DateTime.UtcNow,
+                ModificationDate = DateTime.UtcNow
+            })
+            .Save("utfil-åäö-filen.pdf");
+    }
 }

--- a/Source/QuestPDF.ZUGFeRD/QuestPDF.ZUGFeRD.csproj
+++ b/Source/QuestPDF.ZUGFeRD/QuestPDF.ZUGFeRD.csproj
@@ -25,6 +25,9 @@
     </ItemGroup>
 
     <ItemGroup>
+        <None Update="innehåller-icke-ascii.txt">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Update="resource-factur-x.xml">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/Source/QuestPDF.ZUGFeRD/innehåller-icke-ascii.txt
+++ b/Source/QuestPDF.ZUGFeRD/innehåller-icke-ascii.txt
@@ -1,0 +1,1 @@
+Här har vi konstiga tecken så som å, ä och ö!

--- a/Source/QuestPDF/Qpdf/QpdfAPI.cs
+++ b/Source/QuestPDF/Qpdf/QpdfAPI.cs
@@ -28,7 +28,10 @@ class QpdfAPI
         // perform the job
         var jobHandle = API.qpdfjob_init();
         API.qpdfjob_set_logger(jobHandle, logger);
-        API.qpdfjob_initialize_from_json(jobHandle, jobJson);
+
+        byte[] utf8JsonBytes = Encoding.UTF8.GetBytes(jobJson + "\0"); // Ensure null termination
+        API.qpdfjob_initialize_from_json(jobHandle, utf8JsonBytes);
+
         API.qpdfjob_run(jobHandle);
         API.qpdfjob_cleanup(jobHandle);
         
@@ -78,9 +81,9 @@ class QpdfAPI
     
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void qpdfjob_cleanup(IntPtr jobHandle);
-    
+
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int qpdfjob_initialize_from_json(IntPtr jobHandle, string json);
+        public static extern int qpdfjob_initialize_from_json(IntPtr jobHandle, byte[] json);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int qpdfjob_run(IntPtr jobHandle);


### PR DESCRIPTION
- Introduced `NonAscii_Test` in `GenerationTest.cs` to verify PDF generation with non-ASCII characters.
- Updated `QuestPDF.ZUGFeRD.csproj` to include `innehåller-icke-ascii.txt` for output directory.
- Changed `qpdfjob_initialize_from_json` in `QpdfAPI.cs` to accept a byte array, ensuring proper handling of UTF-8 JSON.
- Modified `innehåller-icke-ascii.txt` to include non-ASCII text for testing purposes.

Fixes #1118 