### PR TITLE
feat(encryption): expose AllowModification on 128/256-bit encryption

### DIFF
--- a/Source/QuestPDF.UnitTests/DocumentOperationTests.cs
+++ b/Source/QuestPDF.UnitTests/DocumentOperationTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
+using QuestPDF.Qpdf;
 
 namespace QuestPDF.UnitTests;
 
@@ -217,6 +218,55 @@ public class DocumentOperationTests
             .Save("operation-extend-metadata.pdf");
     }
     
+    [Test]
+    public void Encryption256_AllowModification_MapsToModifyOtherFlag()
+    {
+        GenerateSampleDocument("allow-modification-256-input.pdf", Colors.Red.Medium, 1);
+
+        var disabled = DocumentOperation
+            .LoadFile("allow-modification-256-input.pdf")
+            .Encrypt(new DocumentOperation.Encryption256Bit { OwnerPassword = "owner", AllowModification = false });
+        Assert.That(disabled.Configuration.Encrypt!.Options256Bit!.ModifyOther, Is.EqualTo("n"));
+        Assert.That(SimpleJsonSerializer.Serialize(disabled.Configuration), Does.Contain("modifyOther"));
+
+        var enabled = DocumentOperation
+            .LoadFile("allow-modification-256-input.pdf")
+            .Encrypt(new DocumentOperation.Encryption256Bit { OwnerPassword = "owner", AllowModification = true });
+        Assert.That(enabled.Configuration.Encrypt!.Options256Bit!.ModifyOther, Is.EqualTo("y"));
+    }
+
+    [Test]
+    public void Encryption128_AllowModification_MapsToModifyOtherFlag()
+    {
+        GenerateSampleDocument("allow-modification-128-input.pdf", Colors.Red.Medium, 1);
+
+        var disabled = DocumentOperation
+            .LoadFile("allow-modification-128-input.pdf")
+            .Encrypt(new DocumentOperation.Encryption128Bit { OwnerPassword = "owner", AllowModification = false });
+        Assert.That(disabled.Configuration.Encrypt!.Options128Bit!.ModifyOther, Is.EqualTo("n"));
+
+        var enabled = DocumentOperation
+            .LoadFile("allow-modification-128-input.pdf")
+            .Encrypt(new DocumentOperation.Encryption128Bit { OwnerPassword = "owner", AllowModification = true });
+        Assert.That(enabled.Configuration.Encrypt!.Options128Bit!.ModifyOther, Is.EqualTo("y"));
+    }
+
+    [Test]
+    public void Encryption40_AllowModification_MapsToModifyFlag()
+    {
+        GenerateSampleDocument("allow-modification-40-input.pdf", Colors.Red.Medium, 1);
+
+        var disabled = DocumentOperation
+            .LoadFile("allow-modification-40-input.pdf")
+            .Encrypt(new DocumentOperation.Encryption40Bit { OwnerPassword = "owner", AllowModification = false });
+        Assert.That(disabled.Configuration.Encrypt!.Options40Bit!.Modify, Is.EqualTo("none"));
+
+        var enabled = DocumentOperation
+            .LoadFile("allow-modification-40-input.pdf")
+            .Encrypt(new DocumentOperation.Encryption40Bit { OwnerPassword = "owner", AllowModification = true });
+        Assert.That(enabled.Configuration.Encrypt!.Options40Bit!.Modify, Is.EqualTo("all"));
+    }
+
     private void GenerateSampleDocument(string filePath, Color color, int length)
     {
         Document

--- a/Source/QuestPDF/Fluent/DocumentOperation.cs
+++ b/Source/QuestPDF/Fluent/DocumentOperation.cs
@@ -168,9 +168,12 @@ public sealed class DocumentOperation
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.fillingForms"]/*' />
         public bool AllowFillingForms { get; set; } = true;
 
+        /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.modification"]/*' />
+        public bool AllowModification { get; set; } = true;
+
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.printing"]/*' />
         public bool AllowPrinting { get; set; } = true;
-    
+
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.encryptMetadata"]/*' />
         public bool EncryptMetadata { get; set; } = true;
     }
@@ -189,13 +192,16 @@ public sealed class DocumentOperation
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.fillingForms"]/*' />
         public bool AllowFillingForms { get; set; } = true;
 
+        /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.modification"]/*' />
+        public bool AllowModification { get; set; } = true;
+
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.printing"]/*' />
         public bool AllowPrinting { get; set; } = true;
-    
+
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.encryptMetadata"]/*' />
         public bool EncryptMetadata { get; set; } = true;
     }
-    
+
     internal JobConfiguration Configuration { get; private set; }
     
     private DocumentOperation()
@@ -439,6 +445,7 @@ public sealed class DocumentOperation
                 Assemble = FormatBooleanFlag(encryption.AllowAssembly),
                 Extract = FormatBooleanFlag(encryption.AllowContentExtraction),
                 Form = FormatBooleanFlag(encryption.AllowFillingForms),
+                ModifyOther = FormatBooleanFlag(encryption.AllowModification),
                 Print = encryption.AllowPrinting ? "full" : "none",
                 CleartextMetadata = encryption.EncryptMetadata ? null : string.Empty
             }
@@ -465,6 +472,7 @@ public sealed class DocumentOperation
                 Assemble = FormatBooleanFlag(encryption.AllowAssembly),
                 Extract = FormatBooleanFlag(encryption.AllowContentExtraction),
                 Form = FormatBooleanFlag(encryption.AllowFillingForms),
+                ModifyOther = FormatBooleanFlag(encryption.AllowModification),
                 Print = encryption.AllowPrinting ? "full" : "none",
                 CleartextMetadata = encryption.EncryptMetadata ? null : string.Empty
             }

--- a/Source/QuestPDF/Fluent/DocumentOperation.cs
+++ b/Source/QuestPDF/Fluent/DocumentOperation.cs
@@ -169,6 +169,9 @@ public sealed class DocumentOperation
         public bool AllowFillingForms { get; set; } = true;
 
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.modification"]/*' />
+        /// <remarks>Maps to the PDF "modify contents" permission (qpdf <c>modifyOther</c>): general content edits,
+        /// independent of the annotation, form-filling and assembly permissions controlled by
+        /// <see cref="AllowAnnotation"/>, <see cref="AllowFillingForms"/> and <see cref="AllowAssembly"/>.</remarks>
         public bool AllowModification { get; set; } = true;
 
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.printing"]/*' />
@@ -193,6 +196,9 @@ public sealed class DocumentOperation
         public bool AllowFillingForms { get; set; } = true;
 
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.modification"]/*' />
+        /// <remarks>Maps to the PDF "modify contents" permission (qpdf <c>modifyOther</c>): general content edits,
+        /// independent of the annotation, form-filling and assembly permissions controlled by
+        /// <see cref="AllowAnnotation"/>, <see cref="AllowFillingForms"/> and <see cref="AllowAssembly"/>.</remarks>
         public bool AllowModification { get; set; } = true;
 
         /// <include file='../Resources/Documentation.xml' path='documentation/doc[@for="documentOperation.encryption.allow.printing"]/*' />

--- a/Source/QuestPDF/Qpdf/JobConfiguration.cs
+++ b/Source/QuestPDF/Qpdf/JobConfiguration.cs
@@ -78,7 +78,7 @@ sealed class JobConfiguration
         [Name("assemble")] public string Assemble { get; set; }
         [Name("extract")] public string Extract { get; set; }
         [Name("form")] public string Form { get; set; }
-        [Name("modifyOther")] public string? ModifyOther { get; set; }
+        [Name("modifyOther")] public string ModifyOther { get; set; }
         [Name("print")] public string? Print { get; set; }
         [Name("useAes")] public string? UseAES { get; set; } = "y";
         [Name("cleartextMetadata")] public string? CleartextMetadata { get; set; }
@@ -90,7 +90,7 @@ sealed class JobConfiguration
         [Name("assemble")] public string Assemble { get; set; }
         [Name("extract")] public string Extract { get; set; }
         [Name("form")] public string Form { get; set; }
-        [Name("modifyOther")] public string? ModifyOther { get; set; }
+        [Name("modifyOther")] public string ModifyOther { get; set; }
         [Name("print")] public string? Print { get; set; }
         [Name("cleartextMetadata")] public string? CleartextMetadata { get; set; }
     }

--- a/Source/QuestPDF/Qpdf/JobConfiguration.cs
+++ b/Source/QuestPDF/Qpdf/JobConfiguration.cs
@@ -78,6 +78,7 @@ sealed class JobConfiguration
         [Name("assemble")] public string Assemble { get; set; }
         [Name("extract")] public string Extract { get; set; }
         [Name("form")] public string Form { get; set; }
+        [Name("modifyOther")] public string? ModifyOther { get; set; }
         [Name("print")] public string? Print { get; set; }
         [Name("useAes")] public string? UseAES { get; set; } = "y";
         [Name("cleartextMetadata")] public string? CleartextMetadata { get; set; }
@@ -89,6 +90,7 @@ sealed class JobConfiguration
         [Name("assemble")] public string Assemble { get; set; }
         [Name("extract")] public string Extract { get; set; }
         [Name("form")] public string Form { get; set; }
+        [Name("modifyOther")] public string? ModifyOther { get; set; }
         [Name("print")] public string? Print { get; set; }
         [Name("cleartextMetadata")] public string? CleartextMetadata { get; set; }
     }


### PR DESCRIPTION
Add an AllowModification permission to Encryption128Bit and Encryption256Bit (Encryption40Bit already exposed it), mapped to qpdf's granular modifyOther flag so it controls the 'modify contents' permission bit independently of the existing annotate/assemble/form flags. Previously the 128/256-bit handlers emitted no modify flag at all, leaving that permission allowed with no way to disable it through the API.