### PR TITLE
Discover Table elements within SemanticTable containers

### DIFF
--- a/src/dotnet/library/QuestPDF.ConformanceTests/Table/SemanticTableDiscoveryTests.cs
+++ b/src/dotnet/library/QuestPDF.ConformanceTests/Table/SemanticTableDiscoveryTests.cs
@@ -1,0 +1,125 @@
+using QuestPDF.ConformanceTests.TestEngine;
+using QuestPDF.Drawing;
+using QuestPDF.Drawing.Exceptions;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.ConformanceTests.Table;
+
+/// <summary>
+/// A container marked with the SemanticTable method must lead to a Table element
+/// through single-child containers only. Otherwise, an exception is thrown.
+/// </summary>
+internal class SemanticTableDiscoveryTests
+{
+    [Test]
+    public void MultiChildElementInterruptsTheRelationship()
+    {
+        var document = Document
+            .Create(document =>
+            {
+                document.Page(page =>
+                {
+                    page.Size(PageSizes.A5);
+                    page.Margin(25);
+
+                    page.Content()
+                        .SemanticTable()
+                        .Column(column =>
+                        {
+                            column.Item().Text("Some text");
+                            column.Item().Table(table =>
+                            {
+                                table.ColumnsDefinition(columns => columns.RelativeColumn());
+                                table.Cell().Text("Cell");
+                            });
+                        });
+                });
+            });
+
+        Assert.Throws<DocumentComposeException>(() => document.TestSemanticTree(null));
+    }
+
+    [Test]
+    public void MissingTableThrowsException()
+    {
+        var document = Document
+            .Create(document =>
+            {
+                document.Page(page =>
+                {
+                    page.Size(PageSizes.A5);
+                    page.Margin(25);
+
+                    page.Content()
+                        .SemanticTable()
+                        .Text("There is no table here");
+                });
+            });
+
+        Assert.Throws<DocumentComposeException>(() => document.TestSemanticTree(null));
+    }
+
+    [Test]
+    public void TableInsideLazyContentIsDiscovered()
+    {
+        var document = Document
+            .Create(document =>
+            {
+                document.Page(page =>
+                {
+                    page.Size(PageSizes.A5);
+                    page.Margin(25);
+
+                    page.Content()
+                        .Lazy(content =>
+                        {
+                            content
+                                .SemanticTable()
+                                .Padding(5)
+                                .Table(table =>
+                                {
+                                    table.ColumnsDefinition(columns => columns.RelativeColumn());
+                                    table.Cell().Text("Cell");
+                                });
+                        });
+                });
+            });
+
+        var expectedSemanticTree = ExpectedSemanticTree.DocumentRoot(root =>
+        {
+            root.Child("Table", table =>
+                table.Child("TBody", tbody =>
+                    tbody.Child("TR", tr =>
+                        tr.Child("TD", td => td.Child("P")))));
+        });
+
+        document.TestSemanticTree(expectedSemanticTree);
+    }
+
+    [Test]
+    public void NonSemanticDocumentsAreNotValidated()
+    {
+        var document = Document
+            .Create(document =>
+            {
+                document.Page(page =>
+                {
+                    page.Size(PageSizes.A5);
+                    page.Margin(25);
+
+                    page.Content()
+                        .SemanticTable()
+                        .Text("There is no table here");
+                });
+            });
+
+        // without accessibility conformance settings, semantic tags are ignored and no validation is performed
+        Assert.DoesNotThrow(() =>
+        {
+            using var stream = new MemoryStream();
+            document.WithSettings(DocumentSettings.Default).GeneratePdf(stream);
+        });
+    }
+}

--- a/src/dotnet/library/QuestPDF.ConformanceTests/Table/TableWithIntermediateContainersTests.cs
+++ b/src/dotnet/library/QuestPDF.ConformanceTests/Table/TableWithIntermediateContainersTests.cs
@@ -1,0 +1,93 @@
+using QuestPDF.ConformanceTests.TestEngine;
+using QuestPDF.Drawing;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.ConformanceTests.Table;
+
+/// <summary>
+/// The SemanticTable method does not need to be applied directly on the container receiving the Table invocation.
+/// Single-child styling containers (e.g. Padding, Border, Background) are allowed between them.
+/// </summary>
+internal class TableWithIntermediateContainersTests : ConformanceTestBase
+{
+    protected override Document GetDocumentUnderTest()
+    {
+        return Document
+            .Create(document =>
+            {
+                document.Page(page =>
+                {
+                    page.Margin(60);
+
+                    page.Content()
+                        .Shrink()
+                        .SemanticTable()
+                        .Border(1)
+                        .BorderColor(Colors.Grey.Darken1)
+                        .Background(Colors.Grey.Lighten4)
+                        .Padding(10)
+                        .Table(table =>
+                        {
+                            table.ColumnsDefinition(columns =>
+                            {
+                                columns.RelativeColumn();
+                                columns.RelativeColumn();
+                            });
+
+                            table.Header(header =>
+                            {
+                                header.Cell().Element(CellStyle).Text("Product");
+                                header.Cell().Element(CellStyle).Text("Price");
+                            });
+
+                            table.Cell().Element(CellStyle).Text("Apple");
+                            table.Cell().Element(CellStyle).Text("10");
+
+                            table.Cell().Element(CellStyle).Text("Orange");
+                            table.Cell().Element(CellStyle).Text("15");
+
+                            IContainer CellStyle(IContainer container) =>
+                                container
+                                    .Border(1)
+                                    .BorderColor(Colors.Grey.Lighten2)
+                                    .Padding(8);
+                        });
+                });
+            });
+    }
+
+    protected override SemanticTreeNode? GetExpectedSemanticTree()
+    {
+        return ExpectedSemanticTree.DocumentRoot(root =>
+        {
+            root.Child("Table", table =>
+            {
+                table.Child("THead", thead =>
+                {
+                    thead.Child("TR", row =>
+                    {
+                        row.Child("TH", th => th.Attribute("Table", "Scope", "Column").Child("P"));
+                        row.Child("TH", th => th.Attribute("Table", "Scope", "Column").Child("P"));
+                    });
+                });
+
+                table.Child("TBody", tbody =>
+                {
+                    tbody.Child("TR", row =>
+                    {
+                        row.Child("TD", td => td.Child("P"));
+                        row.Child("TD", td => td.Child("P"));
+                    });
+
+                    tbody.Child("TR", row =>
+                    {
+                        row.Child("TD", td => td.Child("P"));
+                        row.Child("TD", td => td.Child("P"));
+                    });
+                });
+            });
+        });
+    }
+}

--- a/src/dotnet/library/QuestPDF/Drawing/DocumentGenerator.cs
+++ b/src/dotnet/library/QuestPDF/Drawing/DocumentGenerator.cs
@@ -6,6 +6,7 @@ using QuestPDF.Drawing.DocumentCanvases;
 using QuestPDF.Drawing.Exceptions;
 using QuestPDF.Drawing.Proxy;
 using QuestPDF.Elements;
+using QuestPDF.Elements.Table;
 using QuestPDF.Elements.Text;
 using QuestPDF.Elements.Text.Items;
 using QuestPDF.Helpers;
@@ -210,9 +211,10 @@ namespace QuestPDF.Drawing
             if (semanticTreeManager != null)
             {
                 content.ApplySemanticParagraphs();
+                content.ApplySemanticTables();
                 content.InjectSemanticTreeManager(semanticTreeManager);
             }
-            
+
             return content;
         }
 
@@ -534,6 +536,43 @@ namespace QuestPDF.Drawing
                 foreach (var child in content.GetChildren())
                     ApplyInheritedAndGlobalTexStyle(child, documentDefaultTextStyle);
             }
+        }
+
+        /// <summary>
+        /// For every container marked with the SemanticTable method, finds the related Table structure
+        /// and enables its automated accessibility tagging (THead, TBody, TFoot, TR, TH, TD).
+        /// <para>
+        /// The search traverses only single-child containers (e.g. Padding, Border, Background).
+        /// Elements hosting multiple children (e.g. Column, Row) stop the search,
+        /// as the semantic relationship becomes ambiguous.
+        /// </para>
+        /// </summary>
+        internal static void ApplySemanticTables(this Element root)
+        {
+            root.VisitChildren(element =>
+            {
+                if (element is not SemanticTag { TagType: "Table" } semanticTableTag)
+                    return;
+
+                var currentElement = semanticTableTag.Child;
+
+                while (currentElement is ContainerElement containerElement)
+                {
+                    if (currentElement is TableRoot tableRoot)
+                    {
+                        tableRoot.EnableSemanticTagging();
+                        return;
+                    }
+
+                    currentElement = containerElement.Child;
+                }
+
+                throw new DocumentComposeException(
+                    "The container marked with the SemanticTable method does not contain a Table element. " +
+                    "Please call the Table method directly on the marked container, " +
+                    "optionally with single-child styling containers between them (e.g. Padding, Border or Background). " +
+                    "Elements hosting multiple children (e.g. Column, Row or Layers) interrupt this relationship.");
+            });
         }
 
         internal static void ApplySemanticParagraphs(this Element root)

--- a/src/dotnet/library/QuestPDF/Elements/Dynamic.cs
+++ b/src/dotnet/library/QuestPDF/Elements/Dynamic.cs
@@ -207,6 +207,7 @@ namespace QuestPDF.Elements
             if (SemanticTreeManager != null)
             {
                 container.ApplySemanticParagraphs();
+                container.ApplySemanticTables();
                 container.InjectSemanticTreeManager(SemanticTreeManager);
             }
             

--- a/src/dotnet/library/QuestPDF/Elements/Lazy.cs
+++ b/src/dotnet/library/QuestPDF/Elements/Lazy.cs
@@ -65,6 +65,7 @@ internal sealed class Lazy : ContainerElement, ISemanticAware, IContentDirection
         if (SemanticTreeManager != null)
         {
             container.ApplySemanticParagraphs();
+            container.ApplySemanticTables();
             container.InjectSemanticTreeManager(SemanticTreeManager);
         }
         

--- a/src/dotnet/library/QuestPDF/Elements/Table/TableRoot.cs
+++ b/src/dotnet/library/QuestPDF/Elements/Table/TableRoot.cs
@@ -1,0 +1,41 @@
+using QuestPDF.Infrastructure;
+
+namespace QuestPDF.Elements.Table
+{
+    /// <summary>
+    /// Root of the structure composed by the Table API.
+    /// <para>
+    /// Serves as a discovery marker: when a document is semantic-aware, the generator traverses
+    /// the content of every container marked with the SemanticTable method to find this element
+    /// and enable the automated accessibility tagging (Table, THead, TBody, TFoot, TR, TH, TD).
+    /// </para>
+    /// </summary>
+    internal sealed class TableRoot : ContainerElement
+    {
+        public Table HeaderTable { get; set; }
+        public Table ContentTable { get; set; }
+        public Table FooterTable { get; set; }
+
+        public Container HeaderSlot { get; set; }
+        public Container ContentSlot { get; set; }
+        public Container FooterSlot { get; set; }
+
+        private bool IsSemanticTaggingEnabled { get; set; }
+
+        public void EnableSemanticTagging()
+        {
+            if (IsSemanticTaggingEnabled)
+                return;
+
+            IsSemanticTaggingEnabled = true;
+
+            HeaderTable.EnableAutomatedSemanticTagging = true;
+            ContentTable.EnableAutomatedSemanticTagging = true;
+            FooterTable.EnableAutomatedSemanticTagging = true;
+
+            HeaderSlot.CreateProxy(x => new SemanticTag { TagType = "THead", Child = x });
+            ContentSlot.CreateProxy(x => new SemanticTag { TagType = "TBody", Child = x });
+            FooterSlot.CreateProxy(x => new SemanticTag { TagType = "TFoot", Child = x });
+        }
+    }
+}

--- a/src/dotnet/library/QuestPDF/Fluent/TableExtensions.cs
+++ b/src/dotnet/library/QuestPDF/Fluent/TableExtensions.cs
@@ -75,8 +75,6 @@ namespace QuestPDF.Fluent
     
     public sealed class TableDescriptor
     {
-        internal bool EnableAutomatedSemanticTagging { get; set; } = false;
-        
         private Table HeaderTable { get; } = new();
         private Table ContentTable { get; } = new();
         private Table FooterTable { get; } = new();
@@ -159,53 +157,71 @@ namespace QuestPDF.Fluent
 
         internal IElement CreateElement()
         {
-            var container = new Container();
+            var container = new TableRoot
+            {
+                HeaderTable = HeaderTable,
+                ContentTable = ContentTable,
+                FooterTable = FooterTable
+            };
 
             var hasHeader = HeaderTable.Cells.Any();
             var hasFooter = FooterTable.Cells.Any();
-            
+
             ConfigureTable(HeaderTable, Table.TablePartType.Header);
             ConfigureTable(ContentTable, Table.TablePartType.Body);
             ConfigureTable(FooterTable, Table.TablePartType.Footer);
-            
+
             var tableRequiresAdvancedHeaderTagging = Table.DoesTableBodyRequireExtendedHeaderTagging(HeaderTable.Cells, ContentTable.Cells);
             HeaderTable.TableRequiresAdvancedHeaderTagging = tableRequiresAdvancedHeaderTagging;
             ContentTable.TableRequiresAdvancedHeaderTagging = tableRequiresAdvancedHeaderTagging;
             ContentTable.HeaderCells = HeaderTable.Cells;
-            
+
             container
                 .Decoration(decoration =>
                 {
+                    // the slot containers are potential injection points for the accessibility tags (THead, TBody, TFoot),
+                    // applied when the table is later discovered inside a container marked with the SemanticTable method
                     decoration
                         .Before()
                         .ShowIf(hasHeader)
-                        .NonTrackingElement(x => EnableAutomatedSemanticTagging ? x.SemanticTag("THead") : x)
+                        .NonTrackingElement(x =>
+                        {
+                            container.HeaderSlot = (Container)x;
+                            return x;
+                        })
                         .Element(HeaderTable);
-                    
+
                     decoration
                         .Content()
-                        .NonTrackingElement(x => EnableAutomatedSemanticTagging ? x.SemanticTag("TBody") : x)
+                        .NonTrackingElement(x =>
+                        {
+                            container.ContentSlot = (Container)x;
+                            return x;
+                        })
                         .ShowIf(ContentTable.Cells.Any())
                         .Element(ContentTable);
-                    
+
                     decoration
                         .After()
                         .ShowIf(hasFooter)
-                        .NonTrackingElement(x => EnableAutomatedSemanticTagging ? x.SemanticTag("TFoot") : x)
+                        .NonTrackingElement(x =>
+                        {
+                            container.FooterSlot = (Container)x;
+                            return x;
+                        })
                         .Element(FooterTable);
                 });
 
             return container;
-            
+
             void ConfigureTable(Table table, Table.TablePartType tablePartType)
             {
                 if (!table.Columns.Any())
                     throw new DocumentComposeException($"Table should have at least one column. Please call the '{nameof(ColumnsDefinition)}' method to define columns.");
-            
+
                 table.PlanCellPositions();
                 table.ValidateCellPositions();
-                
-                table.EnableAutomatedSemanticTagging = EnableAutomatedSemanticTagging;
+
                 table.PartType = tablePartType;
             }
         }
@@ -223,7 +239,6 @@ namespace QuestPDF.Fluent
         public static void Table(this IContainer element, Action<TableDescriptor> handler)
         {
             var descriptor = new TableDescriptor();
-            descriptor.EnableAutomatedSemanticTagging = element is SemanticTag { TagType: "Table" };
             handler(descriptor);
             element.Element(descriptor.CreateElement());
         }


### PR DESCRIPTION
## What

`SemanticTable()` no longer requires the `Table(...)` call to be made directly on the marked container. The table is now discovered after document composition by traversing downwards through single-child containers, so styling elements between the two calls are fully supported:

```csharp
// previously: silently produced an invalid structure tree (Table containing bare paragraphs)
// now: produces the full Table → THead/TBody → TR → TH/TD structure
container
    .SemanticTable()
    .Border(1)
    .Padding(10)
    .Table(table => ...);
```

When the table cannot be found — a multi-child element (e.g. `Column`, `Row`) interrupts the relationship, or there is no table at all — a `DocumentComposeException` is thrown with an actionable message, instead of silently emitting a non-conformant document.

## Why

The automated tagging decision was previously made at compose time with a direct parent check (`element is SemanticTag { TagType: "Table" }`). A single intermediate element like `.Padding(5)` silently switched the tagging off, degrading the structure tree to a `Table` element containing bare `P` elements — invalid per ISO 14289-1 §7.2 ("Table element may contain only TR, THead, TBody, TFoot and Caption elements") and only detectable by running an external validator. This is a likely explanation for user reports that table accessibility "does not work".

## How

- `TableDescriptor.CreateElement()` now returns a `TableRoot` marker element that keeps references to the three table parts (header/content/footer) and their wrapper slots. Its `EnableSemanticTagging()` method can be invoked any time before drawing: it sets the tagging flags and injects the `THead`/`TBody`/`TFoot` semantic wrappers via the existing `CreateProxy` mechanism, producing a structure identical to the previous compose-time path.
- A new `ApplySemanticTables()` pass runs in `ConfigureContent` (next to the existing `ApplySemanticParagraphs`), only for semantic-aware documents: it finds every `SemanticTag("Table")`, descends through `ContainerElement` links only, and enables the found `TableRoot` — or throws.
- The same pass runs for content composed during rendering (`Lazy` and `Dynamic` elements), which compose after the main pass.
- Documents without PDF/UA / PDF/A-a conformance settings are unaffected: the pass does not run, no exception is thrown, and semantic tags remain inert (matches existing behavior, including the Companion preview path).

No public API changes.

## Testing

- New `TableWithIntermediateContainersTests` conformance fixture (`SemanticTable → Border → Background → Padding → Table`) validated against veraPDF for all PDF/A and PDF/UA-1 levels plus an exact structure-tree assertion.
- New `SemanticTableDiscoveryTests`: multi-child interruption throws, missing table throws, table inside `Lazy` content is discovered, and non-semantic documents are not validated.
- All six existing table conformance fixtures pass unchanged, confirming the deferred wrapper injection reproduces the previous tag structure exactly.
- Full conformance suite: 188/189 (the one failure is the Mustang-based ZUGFeRD test requiring an external executable, unrelated); all 441 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)