### PR TITLE
Fix dead questpdf.com pricing and license guide links

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@ QuestPDF is dual-licensed.
 This document contains the License Selection Guide, the Community License, and the Professional / Enterprise License.
 
 Not sure which license applies to you?
-Visit https://www.questpdf.com/pricing for a human-friendly overview that explains the licensing in plain language. 
+Visit https://www.questpdf.com/pricing.html for a human-friendly overview that explains the licensing in plain language. 
 If anything's still unclear, we're happy to help at contact@questpdf.com.
 
 The FAQ is informational only; in case of any conflict, the license texts in this document prevail.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 QuestPDF is a production-ready library that lets you design documents the way you design software: with clean, maintainable, strong-typed C# code.
 Stop fighting with HTML-to-PDF conversion. Build pixel-perfect reports, invoices, and exports using the language and tools you already love.
 
-The library is free for individuals, non-profits, open-source projects, and organizations under $1M in annual gross revenue. [Read more](https://www.questpdf.com/pricing)
+The library is free for individuals, non-profits, open-source projects, and organizations under $1M in annual gross revenue. [Read more](https://www.questpdf.com/pricing.html)
 
 <br>
 
@@ -20,7 +20,7 @@ The library is free for individuals, non-profits, open-source projects, and orga
 <br>
 [![Nuget package download](https://img.shields.io/nuget/dt/QuestPDF?style=for-the-badge&label=NuGet%20downloads&logo=nuget&color=0277BD&logoColor=white)](https://www.nuget.org/packages/QuestPDF/)
 <br>
-[![QuestPDF License](https://img.shields.io/badge/LICENSE-Community%20and%20commercial-2E7D32?style=for-the-badge&logo=googledocs&logoColor=white)](https://www.questpdf.com/pricing/)
+[![QuestPDF License](https://img.shields.io/badge/LICENSE-Community%20and%20commercial-2E7D32?style=for-the-badge&logo=googledocs&logoColor=white)](https://www.questpdf.com/pricing.html)
 
 <br>
 <hr>
@@ -33,7 +33,7 @@ The library is free for individuals, non-profits, open-source projects, and orga
 &nbsp;&nbsp;•&nbsp;&nbsp;
 [Features Overview](https://www.questpdf.com/features-overview.html)
 &nbsp;&nbsp;•&nbsp;&nbsp;
-[Pricing](https://www.questpdf.com/pricing/)
+[Pricing](https://www.questpdf.com/pricing.html)
 &nbsp;&nbsp;•&nbsp;&nbsp;
 [License](https://www.questpdf.com/license/)
 &nbsp;&nbsp;•&nbsp;&nbsp;
@@ -374,7 +374,7 @@ A model that benefits everyone. Commercial licensing provides businesses with le
 > Free for individuals, non-profits, open-source projects, and organizations under $1M in annual gross revenue.
 
 [![QuestPDF Pricing](https://img.shields.io/badge/view%20pricing-388E3C?style=for-the-badge)](https://www.questpdf.com/license)
-[![QuestPDF License Terms](https://img.shields.io/badge/license%20terms-666666?style=for-the-badge)](https://www.questpdf.com/license/guide)
+[![QuestPDF License Terms](https://img.shields.io/badge/license%20terms-666666?style=for-the-badge)](https://www.questpdf.com/license/guide.html)
 
 <br>
 <br>

--- a/src/dotnet/library/QuestPDF/Helpers/LicenseChecker.cs
+++ b/src/dotnet/library/QuestPDF/Helpers/LicenseChecker.cs
@@ -28,7 +28,7 @@ static class LicenseChecker
             "[QuestPDF] The QuestPDF library is running with the Evaluation license. " +
             "This mode is fully functional and intended only for evaluating the library before choosing a license. " +
             "It must not be used in production. " +
-            "Pricing: https://www.questpdf.com/pricing | License terms: https://www.questpdf.com/license";
+            "Pricing: https://www.questpdf.com/pricing.html | License terms: https://www.questpdf.com/license";
 
         Trace.TraceWarning(warningMessage);
     }
@@ -48,7 +48,7 @@ static class LicenseChecker
             $"- Professional: paid; covers your entire company, with unlimited developers,\n" +
             $"- Enterprise: paid; additionally covers subsidiaries and affiliated companies, includes prioritized support, and off-schedule software updates for critical issues.{newParagraph}" +
             $"Every tier includes the complete feature set; tiers differ only in usage rights and support.{newParagraph}" +
-            $"Visit https://www.questpdf.com/pricing for a human-friendly overview of licensing and pricing.{newParagraph}" +
+            $"Visit https://www.questpdf.com/pricing.html for a human-friendly overview of licensing and pricing.{newParagraph}" +
             $"Visit https://www.questpdf.com/license to access all legal documents.{newParagraph}" +
             $"No license key or activation is required: the setting is a self-declaration, and we simply trust you. By selecting the tier that matches your situation, you help keep QuestPDF sustainable and continuously improving for everyone.{newParagraph}" +
             $"Evaluating at work? You can start right away; that is exactly what the Evaluation tier is for, and the purchasing decision does not need to be yours. When your team is ready, simply forward the pricing page to your team lead or manager.{newParagraph}" +

--- a/src/dotnet/library/QuestPDF/Resources/Description.md
+++ b/src/dotnet/library/QuestPDF/Resources/Description.md
@@ -4,13 +4,13 @@ QuestPDF is a production-ready library that lets you design documents the way yo
 
 Stop fighting with HTML-to-PDF conversion. Build pixel-perfect reports, invoices, and exports using the language and tools you already love.
 
-The library is free for individuals, non-profits, open-source projects, and organizations under $1M in annual gross revenue. [Read more](https://www.questpdf.com/pricing)
+The library is free for individuals, non-profits, open-source projects, and organizations under $1M in annual gross revenue. [Read more](https://www.questpdf.com/pricing.html)
 
 [![GitHub Stars and Stargazers](https://img.shields.io/github/stars/QuestPDF/QuestPDF?style=for-the-badge&label=GitHub%20Stars&logo=github&color=FFEB3B&logoColor=white)](https://github.com/QuestPDF/QuestPDF)
 
 [![Nuget package download](https://img.shields.io/nuget/dt/QuestPDF?style=for-the-badge&label=NuGet%20downloads&logo=nuget&color=0277BD&logoColor=white)](https://www.nuget.org/packages/QuestPDF/)
 
-[![QuestPDF License](https://img.shields.io/badge/LICENSE-Community%20and%20commercial-2E7D32?style=for-the-badge&logo=googledocs&logoColor=white)](https://www.questpdf.com/pricing)
+[![QuestPDF License](https://img.shields.io/badge/LICENSE-Community%20and%20commercial-2E7D32?style=for-the-badge&logo=googledocs&logoColor=white)](https://www.questpdf.com/pricing.html)
 
 ---
 
@@ -22,7 +22,7 @@ The library is free for individuals, non-profits, open-source projects, and orga
 
 [Features Overview](https://www.questpdf.com/features-overview.html)
 
-[Pricing](https://www.questpdf.com/pricing)
+[Pricing](https://www.questpdf.com/pricing.html)
 
 [License](https://www.questpdf.com/license)
 
@@ -283,7 +283,7 @@ A model that benefits everyone. Commercial licensing provides businesses with le
 
 [![QuestPDF Pricing](https://img.shields.io/badge/view%20pricing-388E3C?style=for-the-badge)](https://www.questpdf.com/license)
 
-[![QuestPDF License Terms](https://img.shields.io/badge/license%20terms-666666?style=for-the-badge)](https://www.questpdf.com/license/guide)
+[![QuestPDF License Terms](https://img.shields.io/badge/license%20terms-666666?style=for-the-badge)](https://www.questpdf.com/license/guide.html)
 
 
 

--- a/src/dotnet/library/QuestPDF/Settings.cs
+++ b/src/dotnet/library/QuestPDF/Settings.cs
@@ -10,7 +10,7 @@ namespace QuestPDF
     {
         /// <summary>
         /// <para>Selects the QuestPDF license tier that applies to your usage. Set this once at application startup, before generating the first document.</para>
-        /// <para>For more details, please check the <a href="https://www.questpdf.com/pricing">QuestPDF Pricing webpage</a> and <a href="https://www.questpdf.com/license">QuestPDF License webpage</a>.</para>
+        /// <para>For more details, please check the <a href="https://www.questpdf.com/pricing.html">QuestPDF Pricing webpage</a> and <a href="https://www.questpdf.com/license">QuestPDF License webpage</a>.</para>
         /// </summary>
         public static LicenseType? License { get; set; }
         


### PR DESCRIPTION
## Problem

The questpdf.com website now serves its pricing and license-guide pages with the `.html` extension. All links without the extension now return **404**:

```
$ curl -o /dev/null -w "%{http_code}" https://www.questpdf.com/pricing
404
$ curl -o /dev/null -w "%{http_code}" https://www.questpdf.com/license/guide
404
$ curl -o /dev/null -w "%{http_code}" https://www.questpdf.com/pricing.html
200
$ curl -o /dev/null -w "%{http_code}" https://www.questpdf.com/license/guide.html
200
```

Affected locations (verified on current main, e2663c9):

- `README.md` — "Read more" link (L15), License badge (L23), Pricing link (L36), License Terms badge (L377)
- `LICENSE.md` — L7 plain-text pricing URL
- `src/dotnet/library/QuestPDF/Settings.cs` — L13 XML doc `<a href>` pricing link
- `src/dotnet/library/QuestPDF/Resources/Description.md` — NuGet package description links
- `src/dotnet/library/QuestPDF/Helpers/LicenseChecker.cs` — L31/L51 license-violation message shown to users in generated PDFs

The `LicenseChecker` case matters most: users hitting the license limit are told to visit a dead page.

## Solution

Update all five files to use `/pricing.html` and `/license/guide.html`. All replacement links verified 200 with curl.

## Verification

- All new links in the diff return HTTP 200 (checked each unique URL).
- `dotnet build src/dotnet/library/QuestPDF/QuestPDF.csproj` — 0 errors.

Co-authored-by: FirmamentalSpring <287222957+FirmaSpring@users.noreply.github.com>
