### PR TITLE
fix(row): ignore NaN item heights

### DIFF
--- a/src/dotnet/library/QuestPDF.UnitTests/RowTests.cs
+++ b/src/dotnet/library/QuestPDF.UnitTests/RowTests.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using QuestPDF.Drawing;
 using QuestPDF.Elements;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
+using QuestPDF.UnitTests.TestEngine;
 
 namespace QuestPDF.UnitTests;
 
@@ -214,5 +216,37 @@ public class RowTests
         
         rowContainer.ResetState();
         Assert.That(rowContainer.GetState(), Is.EquivalentTo(new bool[10]));
+    }
+
+    [Test]
+    public void NaNItemHeightDoesNotOverrideTallestItemHeight()
+    {
+        TestPlan
+            .For(plan =>
+            {
+                var row = new Row();
+
+                row.Items.Add(new RowItem
+                {
+                    Type = RowItemType.Relative,
+                    Size = 1,
+                    Child = plan.CreateChild("finite")
+                });
+
+                row.Items.Add(new RowItem
+                {
+                    Type = RowItemType.Relative,
+                    Size = 1,
+                    Child = plan.CreateChild("nan")
+                });
+
+                return row;
+            })
+            .MeasureElement(new Size(100, 100))
+            .ExpectChildMeasure("finite", new Size(50, 100), SpacePlan.FullRender(50, 20))
+            .ExpectChildMeasure("nan", new Size(50, 100), SpacePlan.FullRender(50, float.NaN))
+            .ExpectChildMeasure("finite", new Size(50, 20), SpacePlan.FullRender(50, 20))
+            .ExpectChildMeasure("nan", new Size(50, 20), SpacePlan.FullRender(50, float.NaN))
+            .CheckMeasureResult(SpacePlan.FullRender(100, 20));
     }
 }

--- a/src/dotnet/library/QuestPDF/Elements/Row.cs
+++ b/src/dotnet/library/QuestPDF/Elements/Row.cs
@@ -258,7 +258,7 @@ namespace QuestPDF.Elements
 
                 foreach (var command in renderingCommands)
                 {
-                    if (!command.RowItem.IsRendered)
+                    if (!command.RowItem.IsRendered && !float.IsNaN(command.Measurement.Height))
                         result = Math.Max(result, command.Measurement.Height);
                 }
 


### PR DESCRIPTION
Fixes #1471.

A percentage-sized SVG can report a `NaN` height. The row height calculation introduced in 2026.8 lets that value replace a valid sibling height, which can hide later content. This change ignores `NaN` when selecting the tallest row item and adds focused regression coverage.

Validated with the full UnitTests (442) and LayoutTests (102) suites, the documentation/report/ZUGFeRD suites, the release package build, and the [minimal reproducer](https://github.com/peters/questpdf-row-svg-layout-repro).
